### PR TITLE
[Feature/#65] menuId로 컨트롤러 간 매핑

### DIFF
--- a/src/main/java/com/inhabas/api/controller/BoardController.java
+++ b/src/main/java/com/inhabas/api/controller/BoardController.java
@@ -1,60 +1,17 @@
 package com.inhabas.api.controller;
 
-import com.inhabas.api.dto.board.BoardDto;
-import com.inhabas.api.dto.board.SaveBoardDto;
-import com.inhabas.api.dto.board.UpdateBoardDto;
-
-import com.inhabas.api.service.board.BoardService;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.web.bind.annotation.*;
 
-import javax.validation.Valid;
+public interface BoardController <DetailDto, ListDto, SaveDto, UpdateDto> {
+     DetailDto getBoard(Integer menuId, Integer id);
 
+     Page<ListDto> getBoardList(Integer menuId, Pageable pageable);
 
-@Slf4j
-@Tag(name = "Board")
-@RestController
-@RequestMapping("/board")
-@RequiredArgsConstructor
-public class BoardController {
+     Integer addBoard(Integer menuId, SaveDto saveDto);
 
-    private final BoardService boardService;
+     Integer updateBoard(Integer menuId, UpdateDto updateDto);
 
-    @Operation(description = "게시글 조회")
-    @GetMapping
-    public BoardDto getBoard(@RequestParam Integer id) {
-        return boardService.getBoard(id);
-    }
+     void deleteBoard(Integer id);
 
-    @Operation(description = "모든 게시글 조회")
-    @GetMapping("/all")
-    public Page<BoardDto> getBoardList(
-            Pageable pageable,
-            @RequestParam Integer menuId
-    ) {
-        return boardService.getBoardList(menuId, pageable);
-    }
-
-    @Operation(description = "게시글 추가")
-    @PostMapping
-    public Integer addBoard(@Valid @RequestBody SaveBoardDto saveBoardDto) {
-        return boardService.write(saveBoardDto);
-    }
-
-    @Operation(description = "게시글 수정")
-    @PutMapping
-    public Integer updateBoard(@Valid @RequestBody UpdateBoardDto updateBoardDto) {
-        return boardService.update(updateBoardDto);
-    }
-
-    @Operation(description = "게시글 삭제")
-    @DeleteMapping
-    public void deleteBoard(@RequestParam Integer id) {
-        boardService.delete(id);
-    }
 }

--- a/src/main/java/com/inhabas/api/controller/BoardController.java
+++ b/src/main/java/com/inhabas/api/controller/BoardController.java
@@ -13,5 +13,4 @@ public interface BoardController <DetailDto, ListDto, SaveDto, UpdateDto> {
      Integer updateBoard(Integer menuId, UpdateDto updateDto);
 
      void deleteBoard(Integer id);
-
 }

--- a/src/main/java/com/inhabas/api/controller/BoardController.java
+++ b/src/main/java/com/inhabas/api/controller/BoardController.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Pageable;
 import java.util.Map;
 
 public interface BoardController <DetailDto, ListDto> {
+
      DetailDto getBoard(Integer menuId, Integer id);
 
      Page<ListDto> getBoardList(Integer menuId, Pageable pageable);
@@ -14,5 +15,5 @@ public interface BoardController <DetailDto, ListDto> {
 
      Integer updateBoard(Integer menuId, Map<String, Object> updateDto);
 
-     void deleteBoard(Integer id);
+     void deleteBoard(Integer menuId, Integer id);
 }

--- a/src/main/java/com/inhabas/api/controller/BoardController.java
+++ b/src/main/java/com/inhabas/api/controller/BoardController.java
@@ -3,14 +3,16 @@ package com.inhabas.api.controller;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-public interface BoardController <DetailDto, ListDto, SaveDto, UpdateDto> {
+import java.util.Map;
+
+public interface BoardController <DetailDto, ListDto> {
      DetailDto getBoard(Integer menuId, Integer id);
 
      Page<ListDto> getBoardList(Integer menuId, Pageable pageable);
 
-     Integer addBoard(Integer menuId, SaveDto saveDto);
+     Integer addBoard(Integer menuId, Map<String, Object> saveDto);
 
-     Integer updateBoard(Integer menuId, UpdateDto updateDto);
+     Integer updateBoard(Integer menuId, Map<String, Object> updateDto);
 
      void deleteBoard(Integer id);
 }

--- a/src/main/java/com/inhabas/api/controller/ContestBoardController.java
+++ b/src/main/java/com/inhabas/api/controller/ContestBoardController.java
@@ -13,17 +13,17 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
-@RestController
 @RequestMapping("/board/contest")
 @RequiredArgsConstructor
-public class ContestBoardController {
+@RestController
+public class ContestBoardController implements BoardController <DetailContestBoardDto, ListContestBoardDto, SaveContestBoardDto, UpdateContestBoardDto> {
 
     private final ContestBoardService boardService;
 
     @Operation(description = "공모전 게시판의 게시글 단일 조회")
     @GetMapping
-    public DetailContestBoardDto getBoard(@RequestParam Integer id) {
-        return boardService.getBoard(id);
+    public DetailContestBoardDto getBoard(@RequestParam Integer menuId, @RequestParam Integer id) {
+        return boardService.getBoard(menuId, id);
     }
 
     @Operation(description = "공모전 게시판의 모든 게시글 조회")
@@ -34,13 +34,13 @@ public class ContestBoardController {
 
     @Operation(description = "공모전 게시판 게시글 추가")
     @PostMapping
-    public Integer addBoard(@Valid @RequestBody SaveContestBoardDto dto) {
+    public Integer addBoard(@RequestParam Integer menuId, @Valid @RequestBody SaveContestBoardDto dto) {
         return boardService.write(dto);
     }
 
     @Operation(description = "공모전 게시판의 게시글 수정")
     @PutMapping
-    public Integer updateBoard(@Valid @RequestBody UpdateContestBoardDto dto) {
+    public Integer updateBoard(@RequestParam Integer menuId, @Valid @RequestBody UpdateContestBoardDto dto) {
         return boardService.update(dto);
     }
 
@@ -49,4 +49,5 @@ public class ContestBoardController {
     public void deleteBoard(@RequestParam Integer id) {
         boardService.delete(id);
     }
+
 }

--- a/src/main/java/com/inhabas/api/controller/ContestBoardController.java
+++ b/src/main/java/com/inhabas/api/controller/ContestBoardController.java
@@ -27,7 +27,7 @@ public class ContestBoardController implements BoardController <DetailContestBoa
     }
 
     @Operation(description = "공모전 게시판의 모든 게시글 조회")
-    @GetMapping("all")
+    @GetMapping("/all")
     public Page<ListContestBoardDto> getBoardList(@RequestParam Integer menuId, Pageable pageable) {
         return boardService.getBoardList(menuId, pageable);
     }
@@ -49,5 +49,4 @@ public class ContestBoardController implements BoardController <DetailContestBoa
     public void deleteBoard(@RequestParam Integer id) {
         boardService.delete(id);
     }
-
 }

--- a/src/main/java/com/inhabas/api/controller/ContestBoardController.java
+++ b/src/main/java/com/inhabas/api/controller/ContestBoardController.java
@@ -47,7 +47,7 @@ public class ContestBoardController implements BoardController <DetailContestBoa
 
     @Operation(description = "공모전 게시판의 게시글 삭제")
     @DeleteMapping
-    public void deleteBoard(@RequestParam Integer id) {
+    public void deleteBoard(@RequestParam Integer menuId, @RequestParam Integer id) {
         boardService.delete(id);
     }
 }

--- a/src/main/java/com/inhabas/api/controller/ContestBoardController.java
+++ b/src/main/java/com/inhabas/api/controller/ContestBoardController.java
@@ -12,11 +12,12 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.util.Map;
 
 @RequestMapping("/board/contest")
 @RequiredArgsConstructor
 @RestController
-public class ContestBoardController implements BoardController <DetailContestBoardDto, ListContestBoardDto, SaveContestBoardDto, UpdateContestBoardDto> {
+public class ContestBoardController implements BoardController <DetailContestBoardDto, ListContestBoardDto> {
 
     private final ContestBoardService boardService;
 
@@ -34,14 +35,14 @@ public class ContestBoardController implements BoardController <DetailContestBoa
 
     @Operation(description = "공모전 게시판 게시글 추가")
     @PostMapping
-    public Integer addBoard(@RequestParam Integer menuId, @Valid @RequestBody SaveContestBoardDto dto) {
-        return boardService.write(dto);
+    public Integer addBoard(@RequestParam Integer menuId, @Valid @RequestBody Map<String, Object> saveBoard) {
+        return boardService.write(menuId, new SaveContestBoardDto(saveBoard));
     }
 
     @Operation(description = "공모전 게시판의 게시글 수정")
     @PutMapping
-    public Integer updateBoard(@RequestParam Integer menuId, @Valid @RequestBody UpdateContestBoardDto dto) {
-        return boardService.update(dto);
+    public Integer updateBoard(@RequestParam Integer menuId, @Valid @RequestBody Map<String, Object> updateBoard) {
+        return boardService.update(menuId, new UpdateContestBoardDto(updateBoard));
     }
 
     @Operation(description = "공모전 게시판의 게시글 삭제")

--- a/src/main/java/com/inhabas/api/controller/FrontBoardController.java
+++ b/src/main/java/com/inhabas/api/controller/FrontBoardController.java
@@ -1,0 +1,43 @@
+package com.inhabas.api.controller;
+
+import com.inhabas.api.service.menu.MenuService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/board")
+@RequiredArgsConstructor
+public class FrontBoardController implements BoardController<Object, Object>{
+
+    private final MenuService menuService;
+
+    @Override
+    public Object getBoard(Integer menuId, Integer id) {
+        return menuService.findControllerByMenuId(menuId).get().getBoard(menuId, id);
+    }
+
+    @Override
+    public Page<Object> getBoardList(Integer menuId, Pageable pageable) {
+        return menuService.findControllerByMenuId(menuId).get().getBoardList(menuId, pageable);
+    }
+
+    @Override
+    public void deleteBoard(Integer menuId, Integer id) {
+        menuService.findControllerByMenuId(menuId).get().deleteBoard(menuId, id);
+    }
+
+    @Override
+    public Integer updateBoard(Integer menuId, Map<String, Object> updateDto) {
+        return menuService.findControllerByMenuId(menuId).get().updateBoard(menuId, updateDto);
+    }
+
+    @Override
+    public Integer addBoard(Integer menuId, Map<String, Object> saveDto) {
+        return menuService.findControllerByMenuId(menuId).get().addBoard(menuId, saveDto);
+    }
+}

--- a/src/main/java/com/inhabas/api/controller/NormalBoardController.java
+++ b/src/main/java/com/inhabas/api/controller/NormalBoardController.java
@@ -4,7 +4,6 @@ import com.inhabas.api.dto.board.SaveBoardDto;
 import com.inhabas.api.dto.board.UpdateBoardDto;
 
 import com.inhabas.api.service.board.BoardService;
-import com.inhabas.api.service.menu.MenuService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -15,58 +14,43 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import java.util.Map;
-import java.util.Optional;
 
 @Slf4j
 @Tag(name = "Board")
 @RestController
-@RequestMapping("/board")
+@RequestMapping("/board/normal")
 @RequiredArgsConstructor
 public class NormalBoardController implements BoardController<Object, Object>{
 
     private final BoardService boardService;
 
-    private final MenuService menuService;
-
     @Operation(description = "게시글 조회")
     @GetMapping
     public Object getBoard(@RequestParam Integer menuId, @RequestParam Integer id) {
-        Optional<BoardController> controller = menuService.findControllerByMenuId(menuId);
-        if(!controller.isEmpty())
-            return controller.get().getBoard(menuId, id); // 자동으로 Object 리턴
         return boardService.getBoard(id);
     }
 
     @Operation(description = "모든 게시글 조회")
     @GetMapping("/all")
     public Page<Object> getBoardList(@RequestParam Integer menuId, Pageable pageable) {
-        Optional<BoardController> controller = menuService.findControllerByMenuId(menuId);
-        if(!controller.isEmpty())
-            return controller.get().getBoardList(menuId, pageable);
         return boardService.getBoardList(menuId, pageable);
     }
 
     @Operation(description = "게시글 추가")
     @PostMapping
     public Integer addBoard(@RequestParam Integer menuId, @Valid @RequestBody Map<String, Object> saveBoard) {
-        Optional<BoardController> controller = menuService.findControllerByMenuId(menuId);
-        if(!controller.isEmpty())
-            return controller.get().addBoard(menuId, saveBoard);
         return boardService.write(new SaveBoardDto(saveBoard));
     }
 
     @Operation(description = "게시글 수정")
     @PutMapping
     public Integer updateBoard(@RequestParam Integer menuId, @Valid @RequestBody Map<String, Object> updateBoard) {
-        Optional<BoardController> controller = menuService.findControllerByMenuId(menuId);
-        if(!controller.isEmpty())
-            return controller.get().updateBoard(menuId, updateBoard);
         return boardService.update(new UpdateBoardDto(updateBoard));
     }
 
     @Operation(description = "게시글 삭제")
     @DeleteMapping
-    public void deleteBoard(@RequestParam Integer id) {
+    public void deleteBoard(@RequestParam Integer menuId, @RequestParam Integer id) {
         boardService.delete(id);
     }
 }

--- a/src/main/java/com/inhabas/api/controller/NormalBoardController.java
+++ b/src/main/java/com/inhabas/api/controller/NormalBoardController.java
@@ -1,6 +1,5 @@
 package com.inhabas.api.controller;
 
-import com.inhabas.api.dto.board.BoardDto;
 import com.inhabas.api.dto.board.SaveBoardDto;
 import com.inhabas.api.dto.board.UpdateBoardDto;
 
@@ -15,13 +14,14 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.util.Optional;
 
 @Slf4j
 @Tag(name = "Board")
 @RestController
 @RequestMapping("/board")
 @RequiredArgsConstructor
-public class NormalBoardController implements BoardController<BoardDto, BoardDto, SaveBoardDto, UpdateBoardDto>{
+public class NormalBoardController implements BoardController<Object, Object, SaveBoardDto, UpdateBoardDto>{
 
     private final BoardService boardService;
 
@@ -29,35 +29,37 @@ public class NormalBoardController implements BoardController<BoardDto, BoardDto
 
     @Operation(description = "게시글 조회")
     @GetMapping
-    public BoardDto getBoard(@RequestParam Integer menuId, @RequestParam Integer id) {
-        menuService.findControllerByMenuId(menuId).ifPresent(
-                boardController -> boardController.getBoard(menuId, id));
+    public Object getBoard(@RequestParam Integer menuId, @RequestParam Integer id) {
+        Optional<BoardController> controller = menuService.findControllerByMenuId(menuId);
+        if(!controller.isEmpty())
+            return controller.get().getBoard(menuId, id);
         return boardService.getBoard(id);
     }
 
     @Operation(description = "모든 게시글 조회")
     @GetMapping("/all")
-    public Page<BoardDto> getBoardList(
-            @RequestParam Integer menuId,
-            Pageable pageable) {
-        menuService.findControllerByMenuId(menuId).ifPresent(
-                boardController -> boardController.getBoardList(menuId, pageable));
+    public Page<Object> getBoardList(@RequestParam Integer menuId, Pageable pageable) {
+        Optional<BoardController> controller = menuService.findControllerByMenuId(menuId);
+        if(!controller.isEmpty())
+            return controller.get().getBoardList(menuId, pageable);
         return boardService.getBoardList(menuId, pageable);
     }
 
     @Operation(description = "게시글 추가")
     @PostMapping
     public Integer addBoard(@RequestParam Integer menuId, @Valid @RequestBody SaveBoardDto saveBoardDto) {
-        menuService.findControllerByMenuId(menuId).ifPresent(
-                boardController -> boardController.addBoard(menuId, saveBoardDto));
+        Optional<BoardController> controller = menuService.findControllerByMenuId(menuId);
+        if(!controller.isEmpty())
+            return controller.get().addBoard(menuId, saveBoardDto);
         return boardService.write(saveBoardDto);
     }
 
     @Operation(description = "게시글 수정")
     @PutMapping
     public Integer updateBoard(@RequestParam Integer menuId, @Valid @RequestBody UpdateBoardDto updateBoardDto) {
-        menuService.findControllerByMenuId(menuId).ifPresent(
-                boardController -> boardController.updateBoard(menuId, updateBoardDto));
+        Optional<BoardController> controller = menuService.findControllerByMenuId(menuId);
+        if(!controller.isEmpty())
+            return controller.get().updateBoard(menuId, updateBoardDto);
         return boardService.update(updateBoardDto);
     }
 

--- a/src/main/java/com/inhabas/api/controller/NormalBoardController.java
+++ b/src/main/java/com/inhabas/api/controller/NormalBoardController.java
@@ -14,6 +14,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.util.Map;
 import java.util.Optional;
 
 @Slf4j
@@ -21,7 +22,7 @@ import java.util.Optional;
 @RestController
 @RequestMapping("/board")
 @RequiredArgsConstructor
-public class NormalBoardController implements BoardController<Object, Object, SaveBoardDto, UpdateBoardDto>{
+public class NormalBoardController implements BoardController<Object, Object>{
 
     private final BoardService boardService;
 
@@ -32,7 +33,7 @@ public class NormalBoardController implements BoardController<Object, Object, Sa
     public Object getBoard(@RequestParam Integer menuId, @RequestParam Integer id) {
         Optional<BoardController> controller = menuService.findControllerByMenuId(menuId);
         if(!controller.isEmpty())
-            return controller.get().getBoard(menuId, id);
+            return controller.get().getBoard(menuId, id); // 자동으로 Object 리턴
         return boardService.getBoard(id);
     }
 
@@ -47,20 +48,20 @@ public class NormalBoardController implements BoardController<Object, Object, Sa
 
     @Operation(description = "게시글 추가")
     @PostMapping
-    public Integer addBoard(@RequestParam Integer menuId, @Valid @RequestBody SaveBoardDto saveBoardDto) {
+    public Integer addBoard(@RequestParam Integer menuId, @Valid @RequestBody Map<String, Object> saveBoard) {
         Optional<BoardController> controller = menuService.findControllerByMenuId(menuId);
         if(!controller.isEmpty())
-            return controller.get().addBoard(menuId, saveBoardDto);
-        return boardService.write(saveBoardDto);
+            return controller.get().addBoard(menuId, saveBoard);
+        return boardService.write(new SaveBoardDto(saveBoard));
     }
 
     @Operation(description = "게시글 수정")
     @PutMapping
-    public Integer updateBoard(@RequestParam Integer menuId, @Valid @RequestBody UpdateBoardDto updateBoardDto) {
+    public Integer updateBoard(@RequestParam Integer menuId, @Valid @RequestBody Map<String, Object> updateBoard) {
         Optional<BoardController> controller = menuService.findControllerByMenuId(menuId);
         if(!controller.isEmpty())
-            return controller.get().updateBoard(menuId, updateBoardDto);
-        return boardService.update(updateBoardDto);
+            return controller.get().updateBoard(menuId, updateBoard);
+        return boardService.update(new UpdateBoardDto(updateBoard));
     }
 
     @Operation(description = "게시글 삭제")

--- a/src/main/java/com/inhabas/api/controller/NormalBoardController.java
+++ b/src/main/java/com/inhabas/api/controller/NormalBoardController.java
@@ -1,0 +1,69 @@
+package com.inhabas.api.controller;
+
+import com.inhabas.api.dto.board.BoardDto;
+import com.inhabas.api.dto.board.SaveBoardDto;
+import com.inhabas.api.dto.board.UpdateBoardDto;
+
+import com.inhabas.api.service.board.BoardService;
+import com.inhabas.api.service.menu.MenuService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+@Slf4j
+@Tag(name = "Board")
+@RestController
+@RequestMapping("/board")
+@RequiredArgsConstructor
+public class NormalBoardController implements BoardController<BoardDto, BoardDto, SaveBoardDto, UpdateBoardDto>{
+
+    private final BoardService boardService;
+
+    private final MenuService menuService;
+
+    @Operation(description = "게시글 조회")
+    @GetMapping
+    public BoardDto getBoard(@RequestParam Integer menuId, @RequestParam Integer id) {
+        menuService.findControllerByMenuId(menuId).ifPresent(
+                boardController -> boardController.getBoard(menuId, id));
+        return boardService.getBoard(id);
+    }
+
+    @Operation(description = "모든 게시글 조회")
+    @GetMapping("/all")
+    public Page<BoardDto> getBoardList(
+            @RequestParam Integer menuId,
+            Pageable pageable) {
+        menuService.findControllerByMenuId(menuId).ifPresent(
+                boardController -> boardController.getBoardList(menuId, pageable));
+        return boardService.getBoardList(menuId, pageable);
+    }
+
+    @Operation(description = "게시글 추가")
+    @PostMapping
+    public Integer addBoard(@RequestParam Integer menuId, @Valid @RequestBody SaveBoardDto saveBoardDto) {
+        menuService.findControllerByMenuId(menuId).ifPresent(
+                boardController -> boardController.addBoard(menuId, saveBoardDto));
+        return boardService.write(saveBoardDto);
+    }
+
+    @Operation(description = "게시글 수정")
+    @PutMapping
+    public Integer updateBoard(@RequestParam Integer menuId, @Valid @RequestBody UpdateBoardDto updateBoardDto) {
+        menuService.findControllerByMenuId(menuId).ifPresent(
+                boardController -> boardController.updateBoard(menuId, updateBoardDto));
+        return boardService.update(updateBoardDto);
+    }
+
+    @Operation(description = "게시글 삭제")
+    @DeleteMapping
+    public void deleteBoard(@RequestParam Integer id) {
+        boardService.delete(id);
+    }
+}

--- a/src/main/java/com/inhabas/api/domain/board/NormalBoard.java
+++ b/src/main/java/com/inhabas/api/domain/board/NormalBoard.java
@@ -50,7 +50,6 @@ public class NormalBoard extends BaseEntity {
     protected Set<BoardFile> files = new HashSet<>();
 
     /* constructor */
-
     public NormalBoard(Integer id, String title, String contents) {
         this.id = id;
         this.title = new Title(title);

--- a/src/main/java/com/inhabas/api/domain/board/NormalBoardRepositoryCustom.java
+++ b/src/main/java/com/inhabas/api/domain/board/NormalBoardRepositoryCustom.java
@@ -2,13 +2,12 @@ package com.inhabas.api.domain.board;
 
 import com.inhabas.api.dto.board.BoardDto;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 import java.util.Optional;
 
 public interface NormalBoardRepositoryCustom {
 
-    Page<BoardDto> findAllByMenuId(Integer menuId, Pageable pageable);
+    Page<Object> findAllByMenuId(Integer menuId, Pageable pageable);
     Optional<BoardDto> findDtoById(Integer id);
 }

--- a/src/main/java/com/inhabas/api/domain/board/NormalBoardRepositoryImpl.java
+++ b/src/main/java/com/inhabas/api/domain/board/NormalBoardRepositoryImpl.java
@@ -21,8 +21,8 @@ public class NormalBoardRepositoryImpl implements NormalBoardRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<BoardDto> findAllByMenuId(Integer menuId, Pageable pageable) {
-        List<BoardDto> results = queryFactory.select(Projections.constructor(BoardDto.class,
+    public Page<Object> findAllByMenuId(Integer menuId, Pageable pageable) {
+        List<Object> results = queryFactory.select(Projections.constructor(Object.class,
                         normalBoard.id,
                         normalBoard.title.value,
                         Expressions.asString("").as("contents"),

--- a/src/main/java/com/inhabas/api/domain/board/NormalBoardRepositoryImpl.java
+++ b/src/main/java/com/inhabas/api/domain/board/NormalBoardRepositoryImpl.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -22,7 +23,7 @@ public class NormalBoardRepositoryImpl implements NormalBoardRepositoryCustom {
 
     @Override
     public Page<Object> findAllByMenuId(Integer menuId, Pageable pageable) {
-        List<Object> results = queryFactory.select(Projections.constructor(Object.class,
+        List<BoardDto> results = queryFactory.select(Projections.constructor(BoardDto.class,
                         normalBoard.id,
                         normalBoard.title.value,
                         Expressions.asString("").as("contents"),
@@ -37,7 +38,12 @@ public class NormalBoardRepositoryImpl implements NormalBoardRepositoryCustom {
                 .limit(pageable.getPageSize())
                 .fetch();
 
-        return new PageImpl<>(results, pageable, results.size());
+        List<Object> castToObject = new ArrayList<>();
+        for (BoardDto result : results){
+            castToObject.add((Object) result);
+        }
+
+        return new PageImpl<>(castToObject, pageable, castToObject.size());
     }
 
     private BooleanExpression menuEq(Integer categoryId) {

--- a/src/main/java/com/inhabas/api/domain/contest/ContestBoard.java
+++ b/src/main/java/com/inhabas/api/domain/contest/ContestBoard.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 @Table(name = "contest_board")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DiscriminatorValue("Contest")
 public class ContestBoard extends NormalBoard {
 
     @Embedded

--- a/src/main/java/com/inhabas/api/domain/contest/ContestBoardRepositoryCustom.java
+++ b/src/main/java/com/inhabas/api/domain/contest/ContestBoardRepositoryCustom.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 
 public interface ContestBoardRepositoryCustom {
 
-    Optional<DetailContestBoardDto> findDtoById(Integer id);
+    Optional<DetailContestBoardDto> findDtoById(Integer menuId, Integer id);
 
     Page<ListContestBoardDto> findAllByMenuId(Integer menuId, Pageable pageable);
 

--- a/src/main/java/com/inhabas/api/domain/contest/ContestBoardRepositoryImpl.java
+++ b/src/main/java/com/inhabas/api/domain/contest/ContestBoardRepositoryImpl.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.inhabas.api.domain.contest.QContestBoard.contestBoard;
+import static com.inhabas.api.domain.board.QNormalBoard.normalBoard;
 
 @RequiredArgsConstructor
 public class ContestBoardRepositoryImpl implements ContestBoardRepositoryCustom {
@@ -32,7 +33,7 @@ public class ContestBoardRepositoryImpl implements ContestBoardRepositoryCustom 
         return Optional.ofNullable(queryFactory
                 .select(Projections.constructor(DetailContestBoardDto.class,
                             Expressions.asNumber(id).as("id"),
-                            contestBoard.writer.name.value,
+                            contestBoard.writer.name.value, 
                             contestBoard.title.value,
                             contestBoard.contents.value,
                             contestBoard.association.value,
@@ -43,7 +44,7 @@ public class ContestBoardRepositoryImpl implements ContestBoardRepositoryCustom 
                             contestBoard.updated
                         ))
                 .from(contestBoard)
-                .innerJoin(contestBoard.writer).on(contestBoard.id.eq(id))
+                .innerJoin(contestBoard.writer)
                 .limit(1)
                 .fetchOne());
     }

--- a/src/main/java/com/inhabas/api/domain/contest/ContestBoardRepositoryImpl.java
+++ b/src/main/java/com/inhabas/api/domain/contest/ContestBoardRepositoryImpl.java
@@ -28,7 +28,7 @@ public class ContestBoardRepositoryImpl implements ContestBoardRepositoryCustom 
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Optional<DetailContestBoardDto> findDtoById(Integer id) {
+    public Optional<DetailContestBoardDto> findDtoById(Integer menuId, Integer id) {
         return Optional.ofNullable(queryFactory
                 .select(Projections.constructor(DetailContestBoardDto.class,
                             Expressions.asNumber(id).as("id"),

--- a/src/main/java/com/inhabas/api/domain/menu/Menu.java
+++ b/src/main/java/com/inhabas/api/domain/menu/Menu.java
@@ -27,7 +27,7 @@ public class Menu extends BaseEntity {
     private Integer priority;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "board_type")
+    @Column(name = "menu_type")
     private MenuType type;
 
     @Embedded

--- a/src/main/java/com/inhabas/api/domain/menu/MenuRepository.java
+++ b/src/main/java/com/inhabas/api/domain/menu/MenuRepository.java
@@ -2,5 +2,5 @@ package com.inhabas.api.domain.menu;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MenuRepository extends JpaRepository<Menu, Integer> {
+public interface MenuRepository extends JpaRepository<Menu, Integer>, MenuRepositoryCustom {
 }

--- a/src/main/java/com/inhabas/api/domain/menu/MenuRepositoryCustom.java
+++ b/src/main/java/com/inhabas/api/domain/menu/MenuRepositoryCustom.java
@@ -1,0 +1,7 @@
+package com.inhabas.api.domain.menu;
+
+import java.util.Optional;
+
+public interface MenuRepositoryCustom {
+    Optional<MenuType> findMenuTypeByMenuId(Integer menuId);
+}

--- a/src/main/java/com/inhabas/api/domain/menu/MenuRepositoryImpl.java
+++ b/src/main/java/com/inhabas/api/domain/menu/MenuRepositoryImpl.java
@@ -1,0 +1,19 @@
+package com.inhabas.api.domain.menu;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import static com.inhabas.api.domain.menu.QMenu.menu;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+public class MenuRepositoryImpl {
+    private final JPAQueryFactory queryFactory;
+
+    public Optional<MenuType> findMenuTypeByMenuId(Integer id){
+        return Optional.ofNullable(queryFactory.select(menu.type)
+                .from(menu)
+                .where(menu.id.eq(id))
+                .fetchOne());
+    }
+}

--- a/src/main/java/com/inhabas/api/domain/menu/MenuType.java
+++ b/src/main/java/com/inhabas/api/domain/menu/MenuType.java
@@ -1,16 +1,16 @@
 package com.inhabas.api.domain.menu;
 
 public enum MenuType {
-    list, // 리스트형 게시판 메뉴
-    card,       // 카드형 게시판 메뉴
-    contest,    // 공모전형 게시판 메뉴
-    introduce,
-    album,
-    account,
-    apply,
-    honor,
-    lecture,
-    study,
-    hobby,
+    LIST, // 리스트형 게시판 메뉴
+    CARD,       // 카드형 게시판 메뉴
+    CONTEST,    // 공모전형 게시판 메뉴
+    INTRODUCE,
+    ALBUM,
+    ACCOUNT,
+    APPLY,
+    HONOR,
+    LECTURE,
+    STUDY,
+    HOBBY,
     DEFAULT     // 관리자에 의해 변경 불가능한 메뉴
 }

--- a/src/main/java/com/inhabas/api/domain/menu/MenuType.java
+++ b/src/main/java/com/inhabas/api/domain/menu/MenuType.java
@@ -2,12 +2,12 @@ package com.inhabas.api.domain.menu;
 
 public enum MenuType {
     LIST, // 리스트형 게시판 메뉴
-    CARD,       // 카드형 게시판 메뉴
     CONTEST,    // 공모전형 게시판 메뉴
     INTRODUCE,
     ALBUM,
-    ACCOUNT,
-    APPLY,
+    BUDGET_ACCOUNT,
+    BUDGET_SUPPORT,
+    GRADUATED,
     HONOR,
     LECTURE,
     STUDY,

--- a/src/main/java/com/inhabas/api/domain/menu/MenuType.java
+++ b/src/main/java/com/inhabas/api/domain/menu/MenuType.java
@@ -1,7 +1,16 @@
 package com.inhabas.api.domain.menu;
 
 public enum MenuType {
-    LIST,       // 리스트형 게시판 메뉴
-    CARD,       // 카드형 게시판 메뉴
+    list, // 리스트형 게시판 메뉴
+    card,       // 카드형 게시판 메뉴
+    contest,    // 공모전형 게시판 메뉴
+    introduce,
+    album,
+    account,
+    apply,
+    honor,
+    lecture,
+    study,
+    hobby,
     DEFAULT     // 관리자에 의해 변경 불가능한 메뉴
 }

--- a/src/main/java/com/inhabas/api/dto/board/SaveBoardDto.java
+++ b/src/main/java/com/inhabas/api/dto/board/SaveBoardDto.java
@@ -8,6 +8,7 @@ import org.hibernate.validator.constraints.Length;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
+import java.util.Map;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -22,7 +23,7 @@ public class SaveBoardDto {
     @NotNull
     private Integer menuId;
 
-    @NotNull
+    @NotNull(message = "로그인 후 이용해주세요.")
     private Integer loginedUser;
 
     public SaveBoardDto(String title, String contents, Integer menuId, Integer loginedUser) {
@@ -31,4 +32,11 @@ public class SaveBoardDto {
         this.menuId = menuId;
         this.loginedUser = loginedUser;
     }
+
+    public SaveBoardDto(Map<String, Object> saveBoard) {
+        this.title = saveBoard.get("title").toString();
+        this.contents = saveBoard.get("contents").toString();
+        this.menuId = (Integer) saveBoard.get("menuId");
+        this.loginedUser = (Integer) saveBoard.get("loginedUser");
+}
 }

--- a/src/main/java/com/inhabas/api/dto/board/UpdateBoardDto.java
+++ b/src/main/java/com/inhabas/api/dto/board/UpdateBoardDto.java
@@ -7,6 +7,7 @@ import lombok.Setter;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
+import java.util.Map;
 
 @Getter @Setter
 @NoArgsConstructor
@@ -25,6 +26,12 @@ public class UpdateBoardDto {
         this.id = id;
         this.title = title;
         this.contents = contents;
+    }
+
+    public UpdateBoardDto(Map<String, Object> updateBoard){
+        this.id = (Integer) updateBoard.get("id");
+        this.title = updateBoard.get("title").toString();
+        this.contents = updateBoard.get("contents").toString();
     }
 
 }

--- a/src/main/java/com/inhabas/api/dto/contest/SaveContestBoardDto.java
+++ b/src/main/java/com/inhabas/api/dto/contest/SaveContestBoardDto.java
@@ -10,6 +10,8 @@ import javax.validation.constraints.Future;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -22,6 +24,9 @@ public class SaveContestBoardDto {
 
     @NotBlank(message = "본문을 입력하세요.")
     private String contents;
+
+    @NotNull(message = "메뉴를 선택해주세요.")
+    private Integer menuId;
 
     @Length(max = 100, message = "100자 이내로 작성해주세요.")
     @NotBlank(message = "협회기관을 입력하세요.")
@@ -40,4 +45,15 @@ public class SaveContestBoardDto {
 
     @NotNull(message = "로그인 후 이용해주세요.")
     private Integer loginedUser;
+
+    public SaveContestBoardDto(Map<String, Object> saveBoard) {
+        this.title = saveBoard.get("title").toString();
+        this.contents = saveBoard.get("contents").toString();
+        this.menuId = (Integer) saveBoard.get("menuId");
+        this.loginedUser = (Integer) saveBoard.get("loginedUser");
+        this.association = saveBoard.get("association").toString();
+        this.topic = saveBoard.get("topic").toString();
+        this.start = LocalDate.parse(saveBoard.get("start").toString(), DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+        this.deadline = LocalDate.parse(saveBoard.get("deadline").toString(), DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+    }
 }

--- a/src/main/java/com/inhabas/api/dto/contest/UpdateContestBoardDto.java
+++ b/src/main/java/com/inhabas/api/dto/contest/UpdateContestBoardDto.java
@@ -11,6 +11,8 @@ import javax.validation.constraints.Future;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -40,4 +42,18 @@ public class UpdateContestBoardDto {
     @NotNull(message = "공모전 모집 마감일을 등록해주세요.")
     @Future(message = "이미 모집기간이 종료된 공모전은 등록할 수 없습니다.")
     private LocalDate deadline;
+
+    @NotNull(message = "로그인 후 이용해주세요.")
+    private Integer loginedUser;
+
+    public UpdateContestBoardDto(Map<String, Object> updateBoard) {
+        this.id = (Integer) updateBoard.get("id");
+        this.title = updateBoard.get("title").toString();
+        this.contents = updateBoard.get("contents").toString();
+        this.association = updateBoard.get("association").toString();
+        this.topic = updateBoard.get("topic").toString();
+        this.start = LocalDate.parse(updateBoard.get("start").toString(), DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+        this.deadline = LocalDate.parse(updateBoard.get("deadline").toString(), DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+        this.loginedUser = (Integer) updateBoard.get("loginedUser");
+    }
 }

--- a/src/main/java/com/inhabas/api/service/board/BoardService.java
+++ b/src/main/java/com/inhabas/api/service/board/BoardService.java
@@ -15,6 +15,6 @@ public interface BoardService {
 
     BoardDto getBoard(Integer boardId);
 
-    Page<BoardDto> getBoardList(Integer menuId, Pageable pageable);
+    Page<Object> getBoardList(Integer menuId, Pageable pageable);
 
 }

--- a/src/main/java/com/inhabas/api/service/board/BoardServiceImpl.java
+++ b/src/main/java/com/inhabas/api/service/board/BoardServiceImpl.java
@@ -12,6 +12,7 @@ import com.inhabas.api.dto.board.SaveBoardDto;
 import com.inhabas.api.dto.board.UpdateBoardDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -26,8 +27,8 @@ import javax.transaction.Transactional;
 public class BoardServiceImpl implements BoardService {
 
     private final NormalBoardRepository boardRepository;
-    private final MenuRepository menuRepository;
     private final MemberRepository memberRepository;
+    private final MenuRepository menuRepository;
 
     @Override
     public Integer write(SaveBoardDto saveBoardDto) {

--- a/src/main/java/com/inhabas/api/service/board/BoardServiceImpl.java
+++ b/src/main/java/com/inhabas/api/service/board/BoardServiceImpl.java
@@ -12,7 +12,6 @@ import com.inhabas.api.dto.board.SaveBoardDto;
 import com.inhabas.api.dto.board.UpdateBoardDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -58,7 +57,7 @@ public class BoardServiceImpl implements BoardService {
     }
 
     @Override
-    public Page<BoardDto> getBoardList(Integer menuId, Pageable pageable) {
+    public Page<Object> getBoardList(Integer menuId, Pageable pageable) {
             return boardRepository.findAllByMenuId(menuId, pageable);
     }
 }

--- a/src/main/java/com/inhabas/api/service/contest/ContestBoardService.java
+++ b/src/main/java/com/inhabas/api/service/contest/ContestBoardService.java
@@ -14,7 +14,7 @@ public interface ContestBoardService {
 
     void delete(Integer id);
 
-    DetailContestBoardDto getBoard(Integer id);
+    DetailContestBoardDto getBoard(Integer menuId, Integer id);
 
     Page<ListContestBoardDto> getBoardList(Integer menuId, Pageable pageable);
 

--- a/src/main/java/com/inhabas/api/service/contest/ContestBoardService.java
+++ b/src/main/java/com/inhabas/api/service/contest/ContestBoardService.java
@@ -8,9 +8,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface ContestBoardService {
-    Integer write(SaveContestBoardDto dto);
+    Integer write(Integer menuId, SaveContestBoardDto dto);
 
-    Integer update(UpdateContestBoardDto dto);
+    Integer update(Integer menuId, UpdateContestBoardDto dto);
 
     void delete(Integer id);
 

--- a/src/main/java/com/inhabas/api/service/contest/ContestBoardServiceImpl.java
+++ b/src/main/java/com/inhabas/api/service/contest/ContestBoardServiceImpl.java
@@ -4,6 +4,8 @@ import com.inhabas.api.domain.contest.ContestBoard;
 import com.inhabas.api.domain.contest.ContestBoardRepository;
 import com.inhabas.api.domain.member.Member;
 import com.inhabas.api.domain.member.MemberRepository;
+import com.inhabas.api.domain.menu.Menu;
+import com.inhabas.api.domain.menu.MenuRepository;
 import com.inhabas.api.dto.contest.DetailContestBoardDto;
 import com.inhabas.api.dto.contest.ListContestBoardDto;
 import com.inhabas.api.dto.contest.SaveContestBoardDto;
@@ -23,10 +25,12 @@ public class ContestBoardServiceImpl implements ContestBoardService{
 
     private final ContestBoardRepository contestBoardRepository;
     private final MemberRepository memberRepository;
+    private final MenuRepository menuRepository;
 
     @Override
-    public Integer write(SaveContestBoardDto dto) {
+    public Integer write(Integer menuId, SaveContestBoardDto dto) {
         Member writer = memberRepository.getById(dto.getLoginedUser());
+        Menu menu = menuRepository.getById(menuId);
         ContestBoard contestBoard = ContestBoard.builder()
                 .title(dto.getTitle())
                 .contents(dto.getContents())
@@ -35,12 +39,15 @@ public class ContestBoardServiceImpl implements ContestBoardService{
                 .start(dto.getStart())
                 .deadline(dto.getDeadline())
                 .build()
-                        .writtenBy(writer);
+                .writtenBy(writer)
+                .inMenu(menu);
         return contestBoardRepository.save(contestBoard).getId();
     }
 
     @Override
-    public Integer update(UpdateContestBoardDto dto) {
+    public Integer update(Integer menuId, UpdateContestBoardDto dto) {
+        Member writer = memberRepository.getById(dto.getLoginedUser());
+        Menu menu = menuRepository.getById(menuId);
         ContestBoard entity = ContestBoard.builder()
                 .id(dto.getId())
                 .title(dto.getTitle())
@@ -49,8 +56,9 @@ public class ContestBoardServiceImpl implements ContestBoardService{
                 .topic(dto.getTopic())
                 .start(dto.getStart())
                 .deadline(dto.getDeadline())
-                .build();
-        // em.merge() 호출되는 지 확인할 것
+                .build()
+                .writtenBy(writer)
+                .inMenu(menu);
         return contestBoardRepository.save(entity).getId();
     }
 

--- a/src/main/java/com/inhabas/api/service/contest/ContestBoardServiceImpl.java
+++ b/src/main/java/com/inhabas/api/service/contest/ContestBoardServiceImpl.java
@@ -61,8 +61,8 @@ public class ContestBoardServiceImpl implements ContestBoardService{
     }
 
     @Override
-    public DetailContestBoardDto getBoard(Integer id) {
-        return  contestBoardRepository.findDtoById(id)
+    public DetailContestBoardDto getBoard(Integer menuId, Integer id) {
+        return  contestBoardRepository.findDtoById(menuId, id)
                 .orElseThrow(()-> new EntityNotFoundException("게시글을 찾을 수 없습니다."));
     }
 

--- a/src/main/java/com/inhabas/api/service/menu/MenuService.java
+++ b/src/main/java/com/inhabas/api/service/menu/MenuService.java
@@ -1,0 +1,11 @@
+package com.inhabas.api.service.menu;
+
+import com.inhabas.api.controller.BoardController;
+
+import java.util.Optional;
+
+public interface MenuService {
+
+   Optional<BoardController> findControllerByMenuId(Integer menuId);
+
+}

--- a/src/main/java/com/inhabas/api/service/menu/MenuServiceImpl.java
+++ b/src/main/java/com/inhabas/api/service/menu/MenuServiceImpl.java
@@ -25,7 +25,7 @@ public class MenuServiceImpl implements MenuService {
         MenuType menuType = menuRepository.findMenuTypeByMenuId(menuId).get();
 
         switch(menuType){
-            case contest:
+            case CONTEST:
                 return Optional.of(context.getBean(ContestBoardController.class));
             default:
                 return Optional.empty(); // NormalBoardController

--- a/src/main/java/com/inhabas/api/service/menu/MenuServiceImpl.java
+++ b/src/main/java/com/inhabas/api/service/menu/MenuServiceImpl.java
@@ -2,6 +2,7 @@ package com.inhabas.api.service.menu;
 
 import com.inhabas.api.controller.BoardController;
 import com.inhabas.api.controller.ContestBoardController;
+import com.inhabas.api.controller.NormalBoardController;
 import com.inhabas.api.domain.menu.MenuRepository;
 import com.inhabas.api.domain.menu.MenuType;
 import lombok.RequiredArgsConstructor;
@@ -28,7 +29,7 @@ public class MenuServiceImpl implements MenuService {
             case CONTEST:
                 return Optional.of(context.getBean(ContestBoardController.class));
             default:
-                return Optional.empty(); // NormalBoardController
+                return Optional.of(context.getBean(NormalBoardController.class));
         }
     }
 }

--- a/src/main/java/com/inhabas/api/service/menu/MenuServiceImpl.java
+++ b/src/main/java/com/inhabas/api/service/menu/MenuServiceImpl.java
@@ -1,0 +1,34 @@
+package com.inhabas.api.service.menu;
+
+import com.inhabas.api.controller.BoardController;
+import com.inhabas.api.controller.ContestBoardController;
+import com.inhabas.api.domain.menu.MenuRepository;
+import com.inhabas.api.domain.menu.MenuType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationContext;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.Optional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MenuServiceImpl implements MenuService {
+
+    private final ApplicationContext context;
+
+    private final MenuRepository menuRepository;
+
+    @Override
+    public Optional<BoardController> findControllerByMenuId(Integer menuId){
+        MenuType menuType = menuRepository.findMenuTypeByMenuId(menuId).get();
+
+        switch(menuType){
+            case contest:
+                return Optional.of(context.getBean(ContestBoardController.class));
+            default:
+                return Optional.empty(); // NormalBoardController
+        }
+    }
+}

--- a/src/test/java/com/inhabas/api/controller/ContestBoardControllerTest.java
+++ b/src/test/java/com/inhabas/api/controller/ContestBoardControllerTest.java
@@ -117,6 +117,7 @@ public class ContestBoardControllerTest {
         // when
         mvc.perform(delete("/board/contest")
                         .contentType(MediaType.APPLICATION_JSON)
+                        .param("menuId", "9")
                         .param("id", "1"))
                 .andExpect(status().isOk());
     }

--- a/src/test/java/com/inhabas/api/controller/ContestBoardControllerTest.java
+++ b/src/test/java/com/inhabas/api/controller/ContestBoardControllerTest.java
@@ -37,7 +37,6 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -79,6 +78,7 @@ public class ContestBoardControllerTest {
         // when
         mvc.perform(post("/board/contest")
                         .contentType(MediaType.APPLICATION_JSON)
+                        .param("menuId", "1")
                         .content(objectMapper.writeValueAsString(saveContestBoardDto)))
                 .andExpect(status().isOk())
                 .andExpect(content().string("1"));
@@ -92,9 +92,10 @@ public class ContestBoardControllerTest {
         given(contestBoardService.update(any(UpdateContestBoardDto.class))).willReturn(1);
 
         // when
-        contestBoardController.updateBoard(updateContestBoardDto);
+        contestBoardController.updateBoard(2, updateContestBoardDto);
         mvc.perform(put("/board/contest")
                         .contentType(MediaType.APPLICATION_JSON)
+                        .param("menuId", "1")
                         .content(objectMapper.writeValueAsString(updateContestBoardDto)))
                 .andExpect(status().isOk())
                 .andExpect(content().string("1"));
@@ -148,11 +149,12 @@ public class ContestBoardControllerTest {
     public void getContestBoardDetail() throws Exception{
         //given
         DetailContestBoardDto contestBoardDto = new DetailContestBoardDto(1, "mingyeom", "title", "contents", "association","topic",  LocalDate.of(2022,01,01), LocalDate.of(2022, 01, 29), LocalDateTime.now(), null);
-        given(contestBoardService.getBoard(anyInt())).willReturn(contestBoardDto);
+        given(contestBoardService.getBoard(anyInt(), anyInt())).willReturn(contestBoardDto);
 
         // when
         String responseBody = mvc.perform(get("/board/contest")
                         .contentType(MediaType.APPLICATION_JSON)
+                        .param("menuId","1")
                         .param("id", "1"))
                 .andExpect(status().isOk())
                 .andReturn()
@@ -172,6 +174,7 @@ public class ContestBoardControllerTest {
         // when
         String errorMessage = mvc.perform(post("/board/contest")
                         .contentType(MediaType.APPLICATION_JSON)
+                        .param("menuId","2")
                         .content(objectMapper.writeValueAsString(saveContestBoardDto)))
                 .andExpect(status().isBadRequest())
                 .andReturn()
@@ -191,6 +194,7 @@ public class ContestBoardControllerTest {
         // when
         String errorMessage = mvc.perform(post("/board/contest")
                         .contentType(MediaType.APPLICATION_JSON)
+                        .param("menuId","1")
                         .content(objectMapper.writeValueAsString(saveContestBoardDto)))
                 .andExpect(status().isBadRequest())
                 .andReturn()

--- a/src/test/java/com/inhabas/api/controller/NormalBoardControllerTest.java
+++ b/src/test/java/com/inhabas/api/controller/NormalBoardControllerTest.java
@@ -87,7 +87,7 @@ public class NormalBoardControllerTest {
         given(boardService.write(any(SaveBoardDto.class))).willReturn(1);
 
         // when
-        mvc.perform(post("/board")
+        mvc.perform(post("/board/normal")
                         .contentType(MediaType.APPLICATION_JSON)
                         .param("menuId","2")
                         .content(objectMapper.writeValueAsString(saveBoardDto)))
@@ -103,7 +103,7 @@ public class NormalBoardControllerTest {
         given(boardService.update(any(UpdateBoardDto.class))).willReturn(1);
 
         // when
-        mvc.perform(put("/board")
+        mvc.perform(put("/board/normal")
                         .contentType(MediaType.APPLICATION_JSON)
                         .param("menuId","2")
                         .content(objectMapper.writeValueAsString(updateBoardDto)))
@@ -118,8 +118,9 @@ public class NormalBoardControllerTest {
         doNothing().when(boardService).delete(anyInt());
 
         // when
-        mvc.perform(delete("/board")
+        mvc.perform(delete("/board/normal")
                         .contentType(MediaType.APPLICATION_JSON)
+                        .param("menuId","2")
                         .param("id", "1"))
                 .andExpect(status().isOk());
     }
@@ -139,7 +140,7 @@ public class NormalBoardControllerTest {
         given(boardService.getBoardList(anyInt(), any())).willReturn(expectedBoardDto);
 
         // when
-        String responseBody = mvc.perform(get("/board/all")
+        String responseBody = mvc.perform(get("/board/normal/all")
                         .contentType(MediaType.APPLICATION_JSON)
                         .param("menuId", "2")
                         .param("page", "2")
@@ -162,7 +163,7 @@ public class NormalBoardControllerTest {
         given(boardService.getBoard(anyInt())).willReturn(boardDto);
 
         // when
-        String responseBody = mvc.perform(get("/board")
+        String responseBody = mvc.perform(get("/board/normal")
                         .contentType(MediaType.APPLICATION_JSON)
                         .param("menuId","2")
                         .param("id", "1"))

--- a/src/test/java/com/inhabas/api/controller/NormalBoardControllerTest.java
+++ b/src/test/java/com/inhabas/api/controller/NormalBoardControllerTest.java
@@ -6,6 +6,7 @@ import com.inhabas.api.dto.board.SaveBoardDto;
 import com.inhabas.api.dto.board.UpdateBoardDto;
 import com.inhabas.api.service.board.BoardService;
 import com.inhabas.api.service.member.MemberService;
+import com.inhabas.api.service.menu.MenuService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -35,12 +36,11 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(BoardController.class)
-public class BoardControllerTest {
+@WebMvcTest(NormalBoardController.class)
+public class NormalBoardControllerTest {
 
     @Autowired
     private MockMvc mvc;
@@ -49,7 +49,7 @@ public class BoardControllerTest {
     private ObjectMapper objectMapper;
 
     @Autowired
-    BoardController boardController;
+    NormalBoardController normalBoardController;
 
     @MockBean
     BoardService boardService;
@@ -60,10 +60,13 @@ public class BoardControllerTest {
     @MockBean
     NormalBoard normalBoard;
 
+    @MockBean
+    MenuService menuService;
+
     @BeforeEach
     public void setUp() {
         mvc = MockMvcBuilders
-                .standaloneSetup(boardController)
+                .standaloneSetup(normalBoardController)
                 .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver())
                 .setViewResolvers(new ViewResolver() {
                     @Override
@@ -84,6 +87,7 @@ public class BoardControllerTest {
         // when
         mvc.perform(post("/board")
                         .contentType(MediaType.APPLICATION_JSON)
+                        .param("menuId","2")
                         .content(objectMapper.writeValueAsString(saveBoardDto)))
                 .andExpect(status().isOk())
                 .andExpect(content().string("1"));
@@ -97,9 +101,10 @@ public class BoardControllerTest {
         given(boardService.update(any(UpdateBoardDto.class))).willReturn(1);
 
         // when
-        boardController.updateBoard(updateBoardDto);
+        normalBoardController.updateBoard(2, updateBoardDto);
         mvc.perform(put("/board")
                         .contentType(MediaType.APPLICATION_JSON)
+                        .param("menuId","2")
                         .content(objectMapper.writeValueAsString(updateBoardDto)))
                 .andExpect(status().isOk())
                 .andExpect(content().string("1"));
@@ -158,6 +163,7 @@ public class BoardControllerTest {
         // when
         String responseBody = mvc.perform(get("/board")
                         .contentType(MediaType.APPLICATION_JSON)
+                        .param("menuId","2")
                         .param("id", "1"))
                 .andExpect(status().isOk())
                 .andReturn()
@@ -177,6 +183,7 @@ public class BoardControllerTest {
         // when
         String errorMessage = mvc.perform(post("/board")
                         .contentType(MediaType.APPLICATION_JSON)
+                        .param("menuId","2")
                         .content(objectMapper.writeValueAsString(saveBoardDto)))
                 .andExpect(status().isBadRequest())
                 .andReturn()
@@ -196,6 +203,7 @@ public class BoardControllerTest {
         // when
         String errorMessage = mvc.perform(post("/board")
                         .contentType(MediaType.APPLICATION_JSON)
+                        .param("menuId","2")
                         .content(objectMapper.writeValueAsString(saveBoardDto)))
                 .andExpect(status().isBadRequest())
                 .andReturn()

--- a/src/test/java/com/inhabas/api/controller/NormalBoardControllerTest.java
+++ b/src/test/java/com/inhabas/api/controller/NormalBoardControllerTest.java
@@ -26,10 +26,12 @@ import org.springframework.web.servlet.View;
 import org.springframework.web.servlet.ViewResolver;
 import org.springframework.web.servlet.view.json.MappingJackson2JsonView;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -97,11 +99,10 @@ public class NormalBoardControllerTest {
     @Test
     public void updateBoard() throws Exception{
         //given
-        UpdateBoardDto updateBoardDto = new UpdateBoardDto(1, "제목을 수정하였습니다.", "내용을 수정하였습니다.");
+        UpdateBoardDto updateBoardDto = new UpdateBoardDto(1, "수정된 제목", "수정된 내용");
         given(boardService.update(any(UpdateBoardDto.class))).willReturn(1);
 
         // when
-        normalBoardController.updateBoard(2, updateBoardDto);
         mvc.perform(put("/board")
                         .contentType(MediaType.APPLICATION_JSON)
                         .param("menuId","2")
@@ -128,12 +129,12 @@ public class NormalBoardControllerTest {
     public void getBoardList() throws Exception {
         PageRequest pageable = PageRequest.of(0,10, Sort.Direction.DESC, "id");
 
-        List<BoardDto> results = new ArrayList<>();
-        results.add(new BoardDto(1, "Shown Title1", null, "Mingyeom", 2, LocalDateTime.now(), null));
-        results.add(new BoardDto(2, "Shown Title2", null, "Mingyeom", 2, LocalDateTime.now(), null));
-        results.add(new BoardDto(3, "Shown Title3", null, "Mingyeom", 2, LocalDateTime.now(), null));
+        List<Object> results = new ArrayList<>();
+        results.add((Object)(new BoardDto(1, "Shown Title1", null, "Mingyeom", 2, LocalDateTime.now(), null)));
+        results.add((Object)(new BoardDto(2, "Shown Title2", null, "Mingyeom", 2, LocalDateTime.now(), null)));
+        results.add((Object)(new BoardDto(3, "Shown Title3", null, "Mingyeom", 2, LocalDateTime.now(), null)));
 
-        Page<BoardDto> expectedBoardDto = new PageImpl<>(results,pageable, results.size());
+        Page<Object> expectedBoardDto = new PageImpl<>(results,pageable, results.size());
 
         given(boardService.getBoardList(anyInt(), any())).willReturn(expectedBoardDto);
 
@@ -172,45 +173,5 @@ public class NormalBoardControllerTest {
         // then
         assertThat(responseBody).isEqualTo(objectMapper.writeValueAsString(boardDto));
 
-    }
-
-    @DisplayName("게시글 작성 시 Title의 길이가 범위를 초과해 오류 발생")
-    @Test
-    public void TitleIsTooLongError() throws Exception {
-        //given
-        SaveBoardDto saveBoardDto = new SaveBoardDto("title".repeat(20) + ".", "contents", 1, 12201863);
-
-        // when
-        String errorMessage = mvc.perform(post("/board")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .param("menuId","2")
-                        .content(objectMapper.writeValueAsString(saveBoardDto)))
-                .andExpect(status().isBadRequest())
-                .andReturn()
-                .getResolvedException().getMessage();
-
-        // then
-        assertThat(errorMessage).isNotBlank();
-        assertThat(errorMessage).contains("제목은 최대 100자입니다.");
-    }
-
-    @DisplayName("게시글 작성 시 Contents가 null인 경우 오류 발생")
-    @Test
-    public void ContentIsNullError() throws Exception {
-        //given
-        SaveBoardDto saveBoardDto = new SaveBoardDto("title", "   ", 1, 12201863);
-
-        // when
-        String errorMessage = mvc.perform(post("/board")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .param("menuId","2")
-                        .content(objectMapper.writeValueAsString(saveBoardDto)))
-                .andExpect(status().isBadRequest())
-                .andReturn()
-                .getResolvedException().getMessage();
-
-        // then
-        assertThat(errorMessage).isNotBlank();
-        assertThat(errorMessage).contains("본문을 입력하세요.");
     }
 }

--- a/src/test/java/com/inhabas/api/domain/BaseEntityTest.java
+++ b/src/test/java/com/inhabas/api/domain/BaseEntityTest.java
@@ -33,7 +33,7 @@ public class BaseEntityTest {
                 Menu.builder()
                 .menuGroup(boardMenuGroup)
                 .priority(2)
-                .type(MenuType.list)
+                .type(MenuType.LIST)
                 .name("자유게시판")
                 .description("부원이 자유롭게 사용할 수 있는 게시판입니다.")
                 .build());

--- a/src/test/java/com/inhabas/api/domain/BaseEntityTest.java
+++ b/src/test/java/com/inhabas/api/domain/BaseEntityTest.java
@@ -33,7 +33,7 @@ public class BaseEntityTest {
                 Menu.builder()
                 .menuGroup(boardMenuGroup)
                 .priority(2)
-                .type(MenuType.LIST)
+                .type(MenuType.list)
                 .name("자유게시판")
                 .description("부원이 자유롭게 사용할 수 있는 게시판입니다.")
                 .build());

--- a/src/test/java/com/inhabas/api/domain/CommentRepositoryTest.java
+++ b/src/test/java/com/inhabas/api/domain/CommentRepositoryTest.java
@@ -45,7 +45,7 @@ public class CommentRepositoryTest {
                 Menu.builder()
                 .menuGroup(boardMenuGroup)
                 .priority(2)
-                .type(MenuType.list)
+                .type(MenuType.LIST)
                 .name("자유게시판")
                 .description("부원이 자유롭게 사용할 수 있는 게시판입니다.")
                 .build());

--- a/src/test/java/com/inhabas/api/domain/CommentRepositoryTest.java
+++ b/src/test/java/com/inhabas/api/domain/CommentRepositoryTest.java
@@ -45,7 +45,7 @@ public class CommentRepositoryTest {
                 Menu.builder()
                 .menuGroup(boardMenuGroup)
                 .priority(2)
-                .type(MenuType.LIST)
+                .type(MenuType.list)
                 .name("자유게시판")
                 .description("부원이 자유롭게 사용할 수 있는 게시판입니다.")
                 .build());

--- a/src/test/java/com/inhabas/api/domain/ContestBoardRepositoryTest.java
+++ b/src/test/java/com/inhabas/api/domain/ContestBoardRepositoryTest.java
@@ -10,7 +10,6 @@ import com.inhabas.api.domain.menu.MenuGroup;
 import com.inhabas.api.domain.menu.MenuType;
 import com.inhabas.api.dto.contest.DetailContestBoardDto;
 import com.inhabas.api.dto.contest.ListContestBoardDto;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,14 +20,12 @@ import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
 import static com.inhabas.api.domain.MemberTest.MEMBER1;
 import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
 
 @DataJpaTest
 @Import(JpaConfig.class)
@@ -52,7 +49,7 @@ public class ContestBoardRepositoryTest {
                 Menu.builder()
                         .menuGroup(boardMenuGroup)
                         .priority(1)
-                        .type(MenuType.LIST)
+                        .type(MenuType.list)
                         .name("공모전게시판")
                         .description("공모전 정보를 알려주는 게시판입니다.")
                         .build());
@@ -83,7 +80,7 @@ public class ContestBoardRepositoryTest {
                         .build();
 
         // when
-        Optional<DetailContestBoardDto> returnedDto = contestBoardRepository.findDtoById(savedContestBoard.getId());
+        Optional<DetailContestBoardDto> returnedDto = contestBoardRepository.findDtoById(1, savedContestBoard.getId());
 
         // then
         assertThat(expectedDto)

--- a/src/test/java/com/inhabas/api/domain/ContestBoardRepositoryTest.java
+++ b/src/test/java/com/inhabas/api/domain/ContestBoardRepositoryTest.java
@@ -49,7 +49,7 @@ public class ContestBoardRepositoryTest {
                 Menu.builder()
                         .menuGroup(boardMenuGroup)
                         .priority(1)
-                        .type(MenuType.list)
+                        .type(MenuType.LIST)
                         .name("공모전게시판")
                         .description("공모전 정보를 알려주는 게시판입니다.")
                         .build());

--- a/src/test/java/com/inhabas/api/domain/MenuRepositoryTest.java
+++ b/src/test/java/com/inhabas/api/domain/MenuRepositoryTest.java
@@ -39,9 +39,9 @@ public class MenuRepositoryTest {
     @Test
     public void CreateNewMenu() {
         //given
-        Menu activityBoardMenu = new Menu(menuGroup1, 1, MenuType.LIST, "동아리 활동", "동아리원의 활동을 기록하는 게시판입니다.");
-        Menu noticeBoardMenu = new Menu(menuGroup2, 1, MenuType.LIST, "공지사항", "동아리 공지를 게시하는 게시판입니다.");
-        Menu freeBoardMenu = new Menu(menuGroup2, 2, MenuType.LIST, "자유게시판", "부원이 자유롭게 글을 작성할 수 있는 게시판입니다.");
+        Menu activityBoardMenu = new Menu(menuGroup1, 1, MenuType.list, "동아리 활동", "동아리원의 활동을 기록하는 게시판입니다.");
+        Menu noticeBoardMenu = new Menu(menuGroup2, 1, MenuType.list, "공지사항", "동아리 공지를 게시하는 게시판입니다.");
+        Menu freeBoardMenu = new Menu(menuGroup2, 2, MenuType.list, "자유게시판", "부원이 자유롭게 글을 작성할 수 있는 게시판입니다.");
 
         //when
         Menu saveActivityMenu = menuRepository.save(activityBoardMenu);
@@ -59,7 +59,7 @@ public class MenuRepositoryTest {
     @Test
     public void UpdateMenuName() {
         //given
-        Menu noticeMenu = menuRepository.save(new Menu(menuGroup2, 1, MenuType.LIST, "공지사항", "동아리 공지를 게시하는 게시판입니다."));
+        Menu noticeMenu = menuRepository.save(new Menu(menuGroup2, 1, MenuType.list, "공지사항", "동아리 공지를 게시하는 게시판입니다."));
         em.flush();em.clear();
 
         //when
@@ -81,16 +81,16 @@ public class MenuRepositoryTest {
          */
 
         //given
-        Menu activityBoardMenu = new Menu(menuGroup1, 1, MenuType.LIST, "동아리 활동", "동아리원의 활동을 기록하는 게시판입니다.");
-        Menu noticeBoardMenu = new Menu(menuGroup2, 1, MenuType.LIST, "공지사항", "동아리 공지를 게시하는 게시판입니다.");
-        Menu freeBoardMenu = new Menu(menuGroup2, 2, MenuType.LIST, "자유게시판", "부원이 자유롭게 글을 작성할 수 있는 게시판입니다.");
+        Menu activityBoardMenu = new Menu(menuGroup1, 1, MenuType.list, "동아리 활동", "동아리원의 활동을 기록하는 게시판입니다.");
+        Menu noticeBoardMenu = new Menu(menuGroup2, 1, MenuType.list, "공지사항", "동아리 공지를 게시하는 게시판입니다.");
+        Menu freeBoardMenu = new Menu(menuGroup2, 2, MenuType.list, "자유게시판", "부원이 자유롭게 글을 작성할 수 있는 게시판입니다.");
         menuRepository.save(activityBoardMenu);
         menuRepository.save(noticeBoardMenu);
         menuRepository.save(freeBoardMenu);
 
         //when
         assertThrows(DataIntegrityViolationException.class,
-                () -> menuRepository.save(new Menu(menuGroup2, 2, MenuType.LIST, "질문게시판", "궁금한 점을 질문하는 게시판입니다.")));
+                () -> menuRepository.save(new Menu(menuGroup2, 2, MenuType.list, "질문게시판", "궁금한 점을 질문하는 게시판입니다.")));
     }
 
 

--- a/src/test/java/com/inhabas/api/domain/MenuRepositoryTest.java
+++ b/src/test/java/com/inhabas/api/domain/MenuRepositoryTest.java
@@ -15,6 +15,9 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.annotation.Import;
 import org.springframework.dao.DataIntegrityViolationException;
 
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @DataJpaTest
@@ -39,9 +42,9 @@ public class MenuRepositoryTest {
     @Test
     public void CreateNewMenu() {
         //given
-        Menu activityBoardMenu = new Menu(menuGroup1, 1, MenuType.list, "동아리 활동", "동아리원의 활동을 기록하는 게시판입니다.");
-        Menu noticeBoardMenu = new Menu(menuGroup2, 1, MenuType.list, "공지사항", "동아리 공지를 게시하는 게시판입니다.");
-        Menu freeBoardMenu = new Menu(menuGroup2, 2, MenuType.list, "자유게시판", "부원이 자유롭게 글을 작성할 수 있는 게시판입니다.");
+        Menu activityBoardMenu = new Menu(menuGroup1, 1, MenuType.LIST, "동아리 활동", "동아리원의 활동을 기록하는 게시판입니다.");
+        Menu noticeBoardMenu = new Menu(menuGroup2, 1, MenuType.LIST, "공지사항", "동아리 공지를 게시하는 게시판입니다.");
+        Menu freeBoardMenu = new Menu(menuGroup2, 2, MenuType.LIST, "자유게시판", "부원이 자유롭게 글을 작성할 수 있는 게시판입니다.");
 
         //when
         Menu saveActivityMenu = menuRepository.save(activityBoardMenu);
@@ -49,7 +52,7 @@ public class MenuRepositoryTest {
         Menu saveFreeMenu = menuRepository.save(freeBoardMenu);
 
         //then
-        Assertions.assertThat(saveActivityMenu)
+        assertThat(saveActivityMenu)
                 .usingRecursiveComparison()
                 .ignoringFields("id")
                 .isEqualTo(activityBoardMenu);
@@ -59,7 +62,7 @@ public class MenuRepositoryTest {
     @Test
     public void UpdateMenuName() {
         //given
-        Menu noticeMenu = menuRepository.save(new Menu(menuGroup2, 1, MenuType.list, "공지사항", "동아리 공지를 게시하는 게시판입니다."));
+        Menu noticeMenu = menuRepository.save(new Menu(menuGroup2, 1, MenuType.LIST, "공지사항", "동아리 공지를 게시하는 게시판입니다."));
         em.flush();em.clear();
 
         //when
@@ -68,7 +71,7 @@ public class MenuRepositoryTest {
                 new Menu(noticeMenu.getId(), noticeMenu.getMenuGroup(), noticeMenu.getPriority(), noticeMenu.getType(), newName, noticeMenu.getDescription()));
 
         //then
-        Assertions.assertThat(updated.getName()).isEqualTo(newName);
+        assertThat(updated.getName()).isEqualTo(newName);
     }
 
     @DisplayName("한 메뉴그룹에, priority 가 중복될 시 오류")
@@ -81,18 +84,31 @@ public class MenuRepositoryTest {
          */
 
         //given
-        Menu activityBoardMenu = new Menu(menuGroup1, 1, MenuType.list, "동아리 활동", "동아리원의 활동을 기록하는 게시판입니다.");
-        Menu noticeBoardMenu = new Menu(menuGroup2, 1, MenuType.list, "공지사항", "동아리 공지를 게시하는 게시판입니다.");
-        Menu freeBoardMenu = new Menu(menuGroup2, 2, MenuType.list, "자유게시판", "부원이 자유롭게 글을 작성할 수 있는 게시판입니다.");
+        Menu activityBoardMenu = new Menu(menuGroup1, 1, MenuType.LIST, "동아리 활동", "동아리원의 활동을 기록하는 게시판입니다.");
+        Menu noticeBoardMenu = new Menu(menuGroup2, 1, MenuType.LIST, "공지사항", "동아리 공지를 게시하는 게시판입니다.");
+        Menu freeBoardMenu = new Menu(menuGroup2, 2, MenuType.LIST, "자유게시판", "부원이 자유롭게 글을 작성할 수 있는 게시판입니다.");
         menuRepository.save(activityBoardMenu);
         menuRepository.save(noticeBoardMenu);
         menuRepository.save(freeBoardMenu);
 
         //when
         assertThrows(DataIntegrityViolationException.class,
-                () -> menuRepository.save(new Menu(menuGroup2, 2, MenuType.list, "질문게시판", "궁금한 점을 질문하는 게시판입니다.")));
+                () -> menuRepository.save(new Menu(menuGroup2, 2, MenuType.LIST, "질문게시판", "궁금한 점을 질문하는 게시판입니다.")));
     }
 
 
+    @DisplayName("메뉴 ID로 메뉴 타입 조회")
+    @Test
+    public void findMenuTypeTest() {
+        // given
+        Menu noticeBoardMenu = new Menu(menuGroup2, 1, MenuType.LIST, "공지사항", "동아리 공지를 게시하는 게시판입니다.");
+        menuRepository.save(noticeBoardMenu);
+
+        // when
+        Optional<MenuType> menuType = menuRepository.findMenuTypeByMenuId(noticeBoardMenu.getId());
+
+        // then
+        assertThat(menuType.get()).isEqualTo(MenuType.LIST);
+    }
 
 }

--- a/src/test/java/com/inhabas/api/domain/NormalBoardRepositoryTest.java
+++ b/src/test/java/com/inhabas/api/domain/NormalBoardRepositoryTest.java
@@ -154,7 +154,7 @@ public class NormalBoardRepositoryTest {
         assertThat(boards.size()).isEqualTo(2);
     }
 
-    @DisplayName("메뉴 id 에 해당하는 게시글들을 갖고 온다.")
+    @DisplayName("메뉴 id 에 해당하는 게시글들을 조회한다.")
     @Test
     public void findAllByMenuId() {
         //given
@@ -165,17 +165,17 @@ public class NormalBoardRepositoryTest {
         Integer noticeBoardId = NOTICE_BOARD.getMenu().getId();
 
         //when
-        Page<BoardDto> freeBoards = boardRepository.findAllByMenuId(freeBoardId, Pageable.ofSize(5));
-        Page<BoardDto> noticeBoards = boardRepository.findAllByMenuId(noticeBoardId, Pageable.ofSize(5));
+        Page<Object> freeBoards = boardRepository.findAllByMenuId(freeBoardId, Pageable.ofSize(5));
+        Page<Object> noticeBoards = boardRepository.findAllByMenuId(noticeBoardId, Pageable.ofSize(5));
 
         //then
         assertThat(freeBoards.getTotalElements()).isEqualTo(1);
         freeBoards.forEach(
-                board->assertThat(board.getMenuId()).isEqualTo(freeBoardId));
+                board->assertThat(((BoardDto)board).getMenuId()).isEqualTo(freeBoardId));
 
         assertThat(noticeBoards.getTotalElements()).isEqualTo(2);
         noticeBoards.forEach(
-                board->assertThat(board.getMenuId()).isEqualTo(noticeBoardId));
+                board->assertThat(((BoardDto)board).getMenuId()).isEqualTo(noticeBoardId));
     }
 
 }

--- a/src/test/java/com/inhabas/api/domain/NormalBoardRepositoryTest.java
+++ b/src/test/java/com/inhabas/api/domain/NormalBoardRepositoryTest.java
@@ -16,7 +16,6 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 import javax.persistence.EntityNotFoundException;
@@ -48,7 +47,7 @@ public class NormalBoardRepositoryTest {
                 Menu.builder()
                         .menuGroup(boardMenuGroup)
                         .priority(1)
-                        .type(MenuType.LIST)
+                        .type(MenuType.list)
                         .name("공지사항")
                         .description("부원이 알아야 할 내용을 게시합니다.")
                         .build());
@@ -56,7 +55,7 @@ public class NormalBoardRepositoryTest {
                 Menu.builder()
                         .menuGroup(boardMenuGroup)
                         .priority(2)
-                        .type(MenuType.LIST)
+                        .type(MenuType.list)
                         .name("자유게시판")
                         .description("부원이 자유롭게 사용할 수 있는 게시판입니다.")
                         .build());

--- a/src/test/java/com/inhabas/api/domain/NormalBoardRepositoryTest.java
+++ b/src/test/java/com/inhabas/api/domain/NormalBoardRepositoryTest.java
@@ -47,7 +47,7 @@ public class NormalBoardRepositoryTest {
                 Menu.builder()
                         .menuGroup(boardMenuGroup)
                         .priority(1)
-                        .type(MenuType.list)
+                        .type(MenuType.LIST)
                         .name("공지사항")
                         .description("부원이 알아야 할 내용을 게시합니다.")
                         .build());
@@ -55,7 +55,7 @@ public class NormalBoardRepositoryTest {
                 Menu.builder()
                         .menuGroup(boardMenuGroup)
                         .priority(2)
-                        .type(MenuType.list)
+                        .type(MenuType.LIST)
                         .name("자유게시판")
                         .description("부원이 자유롭게 사용할 수 있는 게시판입니다.")
                         .build());

--- a/src/test/java/com/inhabas/api/dto/contest/SaveContestBoardDtoTest.java
+++ b/src/test/java/com/inhabas/api/dto/contest/SaveContestBoardDtoTest.java
@@ -37,7 +37,7 @@ public class SaveContestBoardDtoTest {
     @Test
     public void FieldsAreNullError() {
         //given
-        SaveContestBoardDto saveContestBoardDto = new SaveContestBoardDto(null, null, null, null, null, null, null);
+        SaveContestBoardDto saveContestBoardDto = new SaveContestBoardDto(null, null, null, null,  null, null, null, null);
 
         // when
         Set<ConstraintViolation<SaveContestBoardDto>> violations = validator.validate(saveContestBoardDto);
@@ -59,7 +59,7 @@ public class SaveContestBoardDtoTest {
     @Test
     public void FieldsAreBlankedError() {
         // given
-        SaveContestBoardDto saveContestBoardDto = new SaveContestBoardDto(" ", " ", " ", " ", null, null, null);
+        SaveContestBoardDto saveContestBoardDto = new SaveContestBoardDto(" ", " ", null, " ", " ", null, null, null);
 
         //when
         Set<ConstraintViolation<SaveContestBoardDto>> violations = validator.validate(saveContestBoardDto);
@@ -84,6 +84,7 @@ public class SaveContestBoardDtoTest {
         SaveContestBoardDto saveContestBoardDto = new SaveContestBoardDto(
                 "title".repeat(20) + ".",
                 "contents! Cucumber paste has to have a sun-dried, chilled sauerkraut component.",
+                9,
                 "Assoc".repeat(20) + ".",
                 "topic".repeat(100)+ ".",
                 LocalDate.of(2022, 01, 01),
@@ -107,7 +108,7 @@ public class SaveContestBoardDtoTest {
     @Test
     public void DeadlineIsOutdatedError() {
         //given
-        SaveContestBoardDto saveContestBoardDto = new SaveContestBoardDto("title", "contents", "association", "topic",
+        SaveContestBoardDto saveContestBoardDto = new SaveContestBoardDto("title", "contents", 9, "association", "topic",
                 LocalDate.of(2022, 01, 01), LocalDate.of(2022, 02, 01), 12201863);
 
         // when

--- a/src/test/java/com/inhabas/api/dto/contest/UpdateContestBoardDtoTest.java
+++ b/src/test/java/com/inhabas/api/dto/contest/UpdateContestBoardDtoTest.java
@@ -41,7 +41,7 @@ public class UpdateContestBoardDtoTest {
     public void FieldsAreNullError() {
         // given
         UpdateContestBoardDto updateContestBoardDto = new UpdateContestBoardDto(
-            null, null, null, null, null, null, null );
+            null, null, null, null, null, null, null, null );
 
         // when
         Set<ConstraintViolation<UpdateContestBoardDto>> violations = validator.validate(updateContestBoardDto);
@@ -64,7 +64,7 @@ public class UpdateContestBoardDtoTest {
     public void FieldsAreBlankError() {
         // given
         UpdateContestBoardDto updateContestBoardDto = new UpdateContestBoardDto(
-                1, " ", " ", " ", " ", LocalDate.of(2022, 01, 01), LocalDate.of(2023, 02, 10));
+                1, " ", " ", " ", " ", LocalDate.of(2022, 01, 01), LocalDate.of(2023, 02, 10), 12201863);
 
         // when
         Set<ConstraintViolation<UpdateContestBoardDto>> violations = validator.validate(updateContestBoardDto);
@@ -90,7 +90,9 @@ public class UpdateContestBoardDtoTest {
                 "Assoc".repeat(20) + ".",
                 "topic".repeat(100)+ ".",
                 LocalDate.of(2022, 01, 01),
-                LocalDate.of(2022, 03, 03));
+                LocalDate.of(2022, 03, 03),
+                12201863
+        );
 
         // when
         Set<ConstraintViolation<UpdateContestBoardDto>> violations = validator.validate(updateContestBoardDto);

--- a/src/test/java/com/inhabas/api/service/BoardServiceTest.java
+++ b/src/test/java/com/inhabas/api/service/BoardServiceTest.java
@@ -83,18 +83,18 @@ public class BoardServiceTest {
         //given
         PageRequest pageable = PageRequest.of(0,10, Sort.Direction.ASC, "created");
 
-        BoardDto boardDto1 = new BoardDto(1, "title", "contents", "mingyeom",1, LocalDateTime.now(), LocalDateTime.now() );
-        BoardDto boardDto2 = new BoardDto(2, "title", "contents", "minji",1, LocalDateTime.now(), LocalDateTime.now() );
+        Object boardDto1 = (Object) new BoardDto(1, "title", "contents", "mingyeom",1, LocalDateTime.now(), LocalDateTime.now() );
+        Object boardDto2 = (Object) new BoardDto(2, "title", "contents", "minji",1, LocalDateTime.now(), LocalDateTime.now() );
 
-        List<BoardDto> results = new ArrayList<>();
+        List<Object> results = new ArrayList<>();
         results.add(boardDto1);
         results.add(boardDto2);
-        Page<BoardDto> expectedBoardDto = new PageImpl<> (results, pageable, results.size());
+        Page<Object> expectedBoardDto = new PageImpl<> (results, pageable, results.size());
 
         given(boardRepository.findAllByMenuId(any(), any())).willReturn(expectedBoardDto);
 
         //when
-        Page<BoardDto> returnedBoardList = boardService.getBoardList(1, pageable);
+        Page<Object> returnedBoardList = boardService.getBoardList(1, pageable);
 
         //then
         then(boardRepository).should(times(1)).findAllByMenuId(any(), any());

--- a/src/test/java/com/inhabas/api/service/ContestBoardServiceTest.java
+++ b/src/test/java/com/inhabas/api/service/ContestBoardServiceTest.java
@@ -106,13 +106,13 @@ public class ContestBoardServiceTest {
     public void getDetailBoard() {
         //given
         DetailContestBoardDto contestBoardDto = new DetailContestBoardDto(1, "mingyeom", "title", "contents", "association","topic",  LocalDate.of(2022,01,01), LocalDate.of(2022, 01, 29), LocalDateTime.now(), null);
-        given(contestBoardRepository.findDtoById(any())).willReturn(Optional.of(contestBoardDto));
+        given(contestBoardRepository.findDtoById(any(), any())).willReturn(Optional.of(contestBoardDto));
 
         // when
-        contestBoardService.getBoard(1);
+        contestBoardService.getBoard(1,1);
 
         // then
-        then(contestBoardRepository).should(times(1)).findDtoById(any());
+        then(contestBoardRepository).should(times(1)).findDtoById(any(), any());
     }
 
 

--- a/src/test/java/com/inhabas/api/service/ContestBoardServiceTest.java
+++ b/src/test/java/com/inhabas/api/service/ContestBoardServiceTest.java
@@ -4,6 +4,10 @@ import com.inhabas.api.domain.contest.ContestBoard;
 import com.inhabas.api.domain.contest.ContestBoardRepository;
 import com.inhabas.api.domain.member.Member;
 import com.inhabas.api.domain.member.MemberRepository;
+import com.inhabas.api.domain.menu.Menu;
+import com.inhabas.api.domain.menu.MenuGroup;
+import com.inhabas.api.domain.menu.MenuRepository;
+import com.inhabas.api.domain.menu.MenuType;
 import com.inhabas.api.dto.contest.DetailContestBoardDto;
 import com.inhabas.api.dto.contest.ListContestBoardDto;
 import com.inhabas.api.dto.contest.SaveContestBoardDto;
@@ -46,6 +50,9 @@ public class ContestBoardServiceTest {
     @Mock
     MemberRepository memberRepository;
 
+    @Mock
+    MenuRepository menuRepository;
+
     private MockMvc mockMvc;
 
     @BeforeEach
@@ -57,15 +64,24 @@ public class ContestBoardServiceTest {
     @Test
     public void createContestBoard() {
         //given
-        SaveContestBoardDto saveContestBoardDto = new SaveContestBoardDto("title", "contents", "association", "topic", LocalDate.of(2022, 01, 01), LocalDate.of(2022, 01,26) , 12201863);
+        SaveContestBoardDto saveContestBoardDto = new SaveContestBoardDto("title", "contents",9,  "association", "topic", LocalDate.of(2022, 01, 01), LocalDate.of(2022, 01,26) , 12201863);
         ContestBoard contestBoard = new ContestBoard(1, "title", "contents", "association", "topic", LocalDate.of(2022, 01, 01), LocalDate.of(2022, 01,26) );
-        Member writer = new Member(1, "mingyeom", "010-0000-0000","picture", null, null);
+        Member writer = new Member(1, "mingyeom", "010-0000-0000", "picture", null, null);
+        MenuGroup boardMenuGroup = new MenuGroup("게시판");
+        Menu NoticeBoardMenu = Menu.builder()
+                        .menuGroup(boardMenuGroup)
+                        .priority(1)
+                        .type(MenuType.LIST)
+                        .name("공지사항")
+                        .description("부원이 알아야 할 내용을 게시합니다.")
+                        .build();
 
         given(contestBoardRepository.save(any())).willReturn(contestBoard);
         given(memberRepository.getById(anyInt())).willReturn(writer);
+        given(menuRepository.getById(anyInt())).willReturn(NoticeBoardMenu);
 
         // when
-        Integer returnedId = contestBoardService.write(saveContestBoardDto);
+        Integer returnedId = contestBoardService.write(9, saveContestBoardDto);
 
         // then
         then(contestBoardRepository).should(times(1)).save(any());
@@ -139,10 +155,10 @@ public class ContestBoardServiceTest {
 
         given(contestBoardRepository.save(any())).willReturn(expectedContestBoard);
 
-        UpdateContestBoardDto updateContestBoardDto = new UpdateContestBoardDto(1, "수정된 제목", "수정된 내용", "수정된 협회기관명", "수정된 공모전 주제",LocalDate.of(2022, 01, 01), LocalDate.of(2022, 01,26) );
+        UpdateContestBoardDto updateContestBoardDto = new UpdateContestBoardDto(1, "수정된 제목", "수정된 내용", "수정된 협회기관명", "수정된 공모전 주제",LocalDate.of(2022, 01, 01), LocalDate.of(2022, 01,26) ,12201863);
 
         // when
-        Integer returnedId = contestBoardService.update(updateContestBoardDto);
+        Integer returnedId = contestBoardService.update(9, updateContestBoardDto);
 
         // then
         then(contestBoardRepository).should(times(1)).save(any());


### PR DESCRIPTION
- [x] findDtoById 수정 -> normalBoard의 필드 값 불러오기
- [x] NormalBoardController requestBody 수정

NormalBoardController에서 Save, Update시 RequestBody로 받는 Dto는 무조건 NormalBoard와 관련되어져 있다. 
ContestBoardController에서는 다른 ContestBoard의 Dto를 받기 때문에, 요청을 다시 받을 수 없는 관계로 
dto의 획일된 형태(?)를 RequestBody에 넣고 유연하게 변형시켜 이외의 controller의 인자에 넣을 수 있도록 구현해야 한다. 


--> ```Map<String, Object> ``` 자료구조를 이용해 RequestBody를 받고,  Dto 객체로 Cast하여 ```Service```단에 넘겨주어 로직을 처리하였습니다. 
이 방법을 통해서 Front Controller인 NormalBoardController에서 ```@RequestBody``` 에서 dto를 받아 ContestBoardController로 넘길 때 생길 'SaveBoardDto can't cast to SaveContestBoardDto' 문제를 해결할 수 있었습니다. 

그러나 문제는 Bean Validation에 있습니다.
테스트해본 결과  Dto 단에서는 당연히 문제없이 validator를 이용한 테스트가 가능했으나,
 Controller단에서 테스트시 Validation이 어긋나도 Status는 200이 떴습니다.  
(null, 혹은 공백일 경우 최종적으로 저장되지 않고 NullPointerException이 뜨면서 최종적으로 저장되지는 않았습니다. )

https://stackoverflow.com/questions/57026777/how-to-validate-a-mapstring-string-using-spring-validator-programmatically

Custom Validation을 만들어 어떻게 처리할 수 있는 듯한데, 더 고민을 해봐야 될 것  같습니다. 🥺


추가로, controller 객체를 menuService 에서 받아오는 과정에서 
```return controller.get().getBoardList(menuId, pageable)``` 의 반환값이  ```Page<Object>```여서 리스트 조회하는 Controller, Service, Repository 함수의 반환값을 전부 ```Page<Object>``` 로 변환하였습니다. Object를 남발하는 것 같아 좋은 설계인지 모르겠어서, 혹시 의견 있으시면 남겨주세요 !🤔

