### PR TITLE
권한 계층적 적용

### DIFF
--- a/auth-module/src/main/java/com/inhabas/api/auth/AuthSecurityConfig.java
+++ b/auth-module/src/main/java/com/inhabas/api/auth/AuthSecurityConfig.java
@@ -17,7 +17,7 @@ import org.springframework.web.cors.CorsUtils;
 @Order(0) // 인증 관련 security filter chain 은 우선순위가 가장 높아야 함.
 @EnableWebSecurity
 @RequiredArgsConstructor
-@Profile({"!test"}) // 테스트에는 포함시키지 않음.
+@Profile({"dev, local, production"}) // 테스트에는 포함시키지 않음.
 public class AuthSecurityConfig extends WebSecurityConfigurerAdapter {
 
     private final CustomOAuth2UserService customOAuth2UserService;

--- a/resource-server/src/main/java/com/inhabas/api/config/WebSecurityConfig.java
+++ b/resource-server/src/main/java/com/inhabas/api/config/WebSecurityConfig.java
@@ -75,7 +75,7 @@ public class WebSecurityConfig {
     @Order(1)
     @EnableWebSecurity
     @RequiredArgsConstructor
-    @Profile({"local", "dev", "test"})
+    @Profile({"local", "dev", "default_mvc_test"})
     public static class ApiSecurityForDev extends WebSecurityConfigurerAdapter {
 
         private final JwtTokenProvider jwtTokenProvider;

--- a/resource-server/src/main/java/com/inhabas/api/config/WebSecurityConfig.java
+++ b/resource-server/src/main/java/com/inhabas/api/config/WebSecurityConfig.java
@@ -1,18 +1,23 @@
 package com.inhabas.api.config;
 
+import com.inhabas.api.auth.domain.token.jwtUtils.JwtTokenProvider;
 import com.inhabas.api.auth.domain.token.securityFilter.InvalidJwtTokenHandler;
 import com.inhabas.api.auth.domain.token.securityFilter.TokenAuthenticationProcessingFilter;
-import com.inhabas.api.auth.domain.token.jwtUtils.JwtTokenProvider;
 import com.inhabas.api.auth.domain.token.securityFilter.UserPrincipalService;
+import com.inhabas.api.domain.member.security.Hierarchical;
 import com.inhabas.api.domain.member.type.wrapper.Role;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.access.expression.SecurityExpressionHandler;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.FilterInvocation;
+import org.springframework.security.web.access.expression.DefaultWebSecurityExpressionHandler;
 import org.springframework.security.web.authentication.logout.LogoutFilter;
 import org.springframework.web.cors.CorsUtils;
 
@@ -29,6 +34,7 @@ public class WebSecurityConfig {
 
         private final JwtTokenProvider jwtTokenProvider;
         private final UserPrincipalService userPrincipalService;
+        private final Hierarchical hierarchy;
 
         @Override
         protected void configure(HttpSecurity http) throws Exception {
@@ -52,7 +58,16 @@ public class WebSecurityConfig {
                         .antMatchers("/jwt/**").permitAll()
                         .antMatchers(HttpMethod.GET, "/menu/**", "/signUp/schedule", "/member/chief").permitAll()
                         .antMatchers("/signUp/**").hasRole(Role.ANONYMOUS.toString())
-                        .anyRequest().hasRole(Role.BASIC_MEMBER.toString());
+                        .anyRequest().hasRole(Role.BASIC_MEMBER.toString())
+
+                    .expressionHandler(expressionHandler());
+        }
+
+        @Bean
+        public SecurityExpressionHandler<FilterInvocation> expressionHandler() {
+            DefaultWebSecurityExpressionHandler webSecurityExpressionHandler = new DefaultWebSecurityExpressionHandler();
+            webSecurityExpressionHandler.setRoleHierarchy(hierarchy.getHierarchy());
+            return webSecurityExpressionHandler;
         }
     }
 
@@ -60,11 +75,12 @@ public class WebSecurityConfig {
     @Order(1)
     @EnableWebSecurity
     @RequiredArgsConstructor
-    @Profile({"local", "dev"})
+    @Profile({"local", "dev", "test"})
     public static class ApiSecurityForDev extends WebSecurityConfigurerAdapter {
 
         private final JwtTokenProvider jwtTokenProvider;
         private final UserPrincipalService userPrincipalService;
+        private final Hierarchical hierarchy;
 
         @Override
         protected void configure(HttpSecurity http) throws Exception {
@@ -83,6 +99,7 @@ public class WebSecurityConfig {
                     )
 
                     .authorizeRequests()
+                        .expressionHandler(expressionHandler())
                         .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
                         .antMatchers("/swagger", "/swagger-ui/**", "/docs/**", "/jwt/**").permitAll()
                         .antMatchers(HttpMethod.GET, "/menu/**", "/signUp/schedule", "/member/chief").permitAll()
@@ -90,5 +107,11 @@ public class WebSecurityConfig {
                         .anyRequest().hasRole(Role.BASIC_MEMBER.toString());
         }
 
+        @Bean
+        public SecurityExpressionHandler<FilterInvocation> expressionHandler() {
+            DefaultWebSecurityExpressionHandler webSecurityExpressionHandler = new DefaultWebSecurityExpressionHandler();
+            webSecurityExpressionHandler.setRoleHierarchy(hierarchy.getHierarchy());
+            return webSecurityExpressionHandler;
+        }
     }
 }

--- a/resource-server/src/main/java/com/inhabas/api/controller/LoginController.java
+++ b/resource-server/src/main/java/com/inhabas/api/controller/LoginController.java
@@ -1,7 +1,7 @@
 package com.inhabas.api.controller;
 
 import com.inhabas.api.auth.utils.argumentResolver.Authenticated;
-import com.inhabas.api.domain.member.LoginMember;
+import com.inhabas.api.domain.member.security.LoginMember;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,7 +12,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.servlet.http.HttpServletRequest;
-import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -26,7 +25,7 @@ public class LoginController {
     @GetMapping("${authenticate.oauth2-success-handle-url}")
     @Operation(description = "로그인 성공하여 최종적으로 accessToken, refreshToken 을 발행한다.", hidden = true)
     public ResponseEntity<?> successLogin(
-            HttpServletRequest request, @Authenticated LoginMember authUserDetail) throws URISyntaxException {
+            HttpServletRequest request, @Authenticated LoginMember authUserDetail) {
 
         request.getSession().invalidate();
         throw new NotImplementedException("소셜로그인 다시 구현해야함");

--- a/resource-server/src/main/java/com/inhabas/api/controller/SignUpController.java
+++ b/resource-server/src/main/java/com/inhabas/api/controller/SignUpController.java
@@ -1,7 +1,7 @@
 package com.inhabas.api.controller;
 
 import com.inhabas.api.auth.utils.argumentResolver.Authenticated;
-import com.inhabas.api.domain.member.LoginMember;
+import com.inhabas.api.domain.member.security.LoginMember;
 import com.inhabas.api.dto.member.MajorInfoDto;
 import com.inhabas.api.dto.signUp.AnswerDto;
 import com.inhabas.api.dto.signUp.MemberDuplicationQueryCondition;

--- a/resource-server/src/main/java/com/inhabas/api/domain/member/security/DefaultRoleHierarchy.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/member/security/DefaultRoleHierarchy.java
@@ -1,0 +1,53 @@
+package com.inhabas.api.domain.member.security;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchyUtils;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+
+@Component
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DefaultRoleHierarchy implements Hierarchical {
+
+    /* 기존 권한에 ROLE PREFIX 추가해야함. */
+    private static final String ADMIN = "ROLE_ADMIN";
+    private static final String CHIEF = "ROLE_CHIEF";
+    private static final String EXECUTIVES = "ROLE_EXECUTIVES";
+    private static final String BASIC_MEMBER = "ROLE_BASIC_MEMBER";
+    private static final String DEACTIVATED_MEMBER = "ROLE_DEACTIVATED_MEMBER";
+    private static final String NOT_APPROVED_MEMBER = "ROLE_NOT_APPROVED_MEMBER";
+
+
+    @Override
+    public RoleHierarchy getHierarchy() {
+
+        RoleHierarchyImpl roleHierarchy = new RoleHierarchyImpl();
+
+        Map<String, List<String>> roleHierarchyMap = new HashMap<>() {{
+            put(
+                    ADMIN,
+                    Arrays.asList(CHIEF, EXECUTIVES, BASIC_MEMBER, DEACTIVATED_MEMBER, NOT_APPROVED_MEMBER));
+            put(
+                    CHIEF,
+                    Arrays.asList(EXECUTIVES, BASIC_MEMBER, DEACTIVATED_MEMBER, NOT_APPROVED_MEMBER));
+            put(
+                    EXECUTIVES,
+                    Arrays.asList(BASIC_MEMBER, DEACTIVATED_MEMBER, NOT_APPROVED_MEMBER));
+            put(
+                    BASIC_MEMBER,
+                    Arrays.asList(DEACTIVATED_MEMBER, NOT_APPROVED_MEMBER));
+            put(
+                    DEACTIVATED_MEMBER,
+                    List.of(NOT_APPROVED_MEMBER));
+        }};
+
+        String roles = RoleHierarchyUtils.roleHierarchyFromMap(roleHierarchyMap);
+        roleHierarchy.setHierarchy(roles);
+
+        return roleHierarchy;
+    }
+}

--- a/resource-server/src/main/java/com/inhabas/api/domain/member/security/Hierarchical.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/member/security/Hierarchical.java
@@ -1,0 +1,13 @@
+package com.inhabas.api.domain.member.security;
+
+import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
+
+/**
+ * 로그인된 사용자의 권한을 수직적으로 정의한다. (예로, 회장이면 일반 사용자의 모든 권한을 포함하도록 한다.)
+ * 리턴 객체를 Bean 으로 등록해서 SecurityExpressionHandler 에 주입해주어야 적용된다.
+ * 최종적으로는 주입된 SecurityExpressionHandler 빈을 등록해야한다.
+ */
+public interface Hierarchical {
+
+    RoleHierarchy getHierarchy();
+}

--- a/resource-server/src/main/java/com/inhabas/api/domain/member/security/LoginMember.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/member/security/LoginMember.java
@@ -1,6 +1,7 @@
-package com.inhabas.api.domain.member;
+package com.inhabas.api.domain.member.security;
 
 import com.inhabas.api.auth.utils.argumentResolver.ResolvedAuthenticationResult;
+import com.inhabas.api.domain.member.Team;
 import com.inhabas.api.domain.member.type.wrapper.Role;
 
 import java.util.List;

--- a/resource-server/src/main/java/com/inhabas/api/domain/member/security/MemberAuthorityProvider.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/member/security/MemberAuthorityProvider.java
@@ -1,8 +1,10 @@
-package com.inhabas.api.domain.member;
+package com.inhabas.api.domain.member.security;
 
 import com.inhabas.api.auth.domain.oauth2.socialAccount.type.UID;
 import com.inhabas.api.auth.domain.oauth2.userAuthorityProvider.UserAuthorityProvider;
 import com.inhabas.api.auth.domain.oauth2.userInfo.OAuth2UserInfo;
+import com.inhabas.api.domain.member.Member;
+import com.inhabas.api.domain.member.Team;
 import com.inhabas.api.domain.member.security.socialAccount.MemberSocialAccount;
 import com.inhabas.api.domain.member.security.socialAccount.MemberSocialAccountRepository;
 import com.inhabas.api.domain.member.type.wrapper.Role;

--- a/resource-server/src/main/java/com/inhabas/api/domain/member/type/wrapper/Role.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/member/type/wrapper/Role.java
@@ -10,6 +10,6 @@ public enum Role {
     BASIC_MEMBER, // 일반회원
     DEACTIVATED_MEMBER, // 비활동회원
     NOT_APPROVED_MEMBER, // 가입 후 아직 승인되지 않은 회원
-    ANONYMOUS // 익명.
+    ANONYMOUS // 익명. 유일하게 회원가입을 시도할 수 있는 권한. 즉 상위의 권한으로 회원가입 시도 불가
 }
 

--- a/resource-server/src/main/java/com/inhabas/api/service/signup/SignUpService.java
+++ b/resource-server/src/main/java/com/inhabas/api/service/signup/SignUpService.java
@@ -1,6 +1,6 @@
 package com.inhabas.api.service.signup;
 
-import com.inhabas.api.domain.member.LoginMember;
+import com.inhabas.api.domain.member.security.LoginMember;
 import com.inhabas.api.dto.member.MajorInfoDto;
 import com.inhabas.api.dto.signUp.AnswerDto;
 import com.inhabas.api.dto.signUp.MemberDuplicationQueryCondition;

--- a/resource-server/src/main/java/com/inhabas/api/service/signup/SignUpServiceImpl.java
+++ b/resource-server/src/main/java/com/inhabas/api/service/signup/SignUpServiceImpl.java
@@ -1,7 +1,7 @@
 package com.inhabas.api.service.signup;
 
 import com.inhabas.api.auth.utils.argumentResolver.ResolvedAuthenticationResult;
-import com.inhabas.api.domain.member.LoginMember;
+import com.inhabas.api.domain.member.security.LoginMember;
 import com.inhabas.api.domain.member.Member;
 import com.inhabas.api.domain.member.MemberDuplicationChecker;
 import com.inhabas.api.domain.member.type.IbasInformation;

--- a/resource-server/src/main/resources/bootstrap.yml
+++ b/resource-server/src/main/resources/bootstrap.yml
@@ -14,7 +14,7 @@ management:
 spring:
   config:
     activate:
-      on-profile: test
+      on-profile: default_mvc_test, no_security_mvc_test
   cloud:
     discovery:
       enabled: false

--- a/resource-server/src/test/java/com/inhabas/api/controller/LoginControllerTest.java
+++ b/resource-server/src/test/java/com/inhabas/api/controller/LoginControllerTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.MockMvc;
 
+@Disabled
 @DefaultWebMvcTest(LoginController.class)
 public class LoginControllerTest {
 

--- a/resource-server/src/test/java/com/inhabas/api/controller/MemberControllerTest.java
+++ b/resource-server/src/test/java/com/inhabas/api/controller/MemberControllerTest.java
@@ -1,11 +1,9 @@
 package com.inhabas.api.controller;
 
-import com.inhabas.annotataion.WithMockJwtAuthenticationToken;
-import com.inhabas.api.domain.member.type.wrapper.Role;
 import com.inhabas.api.dto.member.ContactDto;
 import com.inhabas.api.service.member.MemberService;
 import com.inhabas.api.service.member.MemberTeamService;
-import com.inhabas.testConfig.DefaultWebMvcTest;
+import com.inhabas.testConfig.NoSecureWebMvcTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,7 +17,7 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@DefaultWebMvcTest(MemberController.class)
+@NoSecureWebMvcTest(MemberController.class)
 public class MemberControllerTest {
 
     @Autowired
@@ -33,7 +31,6 @@ public class MemberControllerTest {
 
     @DisplayName("회원을 한 팀에 추가시킨다.")
     @Test
-    @WithMockJwtAuthenticationToken(memberId = 12151111, memberRole = Role.EXECUTIVES)
     public void addMemberToTeamTest() throws Exception {
         doNothing().when(memberTeamService).addMemberToTeam(anyInt(), anyInt());
 
@@ -45,7 +42,6 @@ public class MemberControllerTest {
 
     @DisplayName("팀에서 회원을 방출시킨다.")
     @Test
-    @WithMockJwtAuthenticationToken(memberId = 12151111, memberRole = Role.EXECUTIVES)
     public void expelMemberFromTeamTest() throws Exception {
         doNothing().when(memberTeamService).deleteMemberFromTeam(anyInt(), anyInt());
 
@@ -57,7 +53,6 @@ public class MemberControllerTest {
 
     @DisplayName("회장 연락처 정보를 불러온다")
     @Test
-    @WithMockJwtAuthenticationToken
     public void getChiefContactInfoTest() throws Exception {
         given(memberService.getChiefContact())
                 .willReturn(new ContactDto("강지훈", "010-0000-0000","my@email.com"));

--- a/resource-server/src/test/java/com/inhabas/api/controller/SignUpControllerTest.java
+++ b/resource-server/src/test/java/com/inhabas/api/controller/SignUpControllerTest.java
@@ -3,7 +3,7 @@ package com.inhabas.api.controller;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.inhabas.annotataion.WithMockJwtAuthenticationToken;
-import com.inhabas.api.domain.member.LoginMember;
+import com.inhabas.api.domain.member.security.LoginMember;
 import com.inhabas.api.domain.member.Member;
 import com.inhabas.api.domain.member.type.MemberType;
 import com.inhabas.api.domain.member.type.wrapper.Role;

--- a/resource-server/src/test/java/com/inhabas/api/securityConfig/RoleHierarchyTest.java
+++ b/resource-server/src/test/java/com/inhabas/api/securityConfig/RoleHierarchyTest.java
@@ -1,0 +1,94 @@
+package com.inhabas.api.securityConfig;
+
+import com.inhabas.api.controller.BoardController;
+import com.inhabas.api.service.board.BoardService;
+import com.inhabas.api.service.member.MemberService;
+import com.inhabas.testConfig.DefaultWebMvcTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DefaultWebMvcTest(BoardController.class)
+public class RoleHierarchyTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    BoardController boardController;
+
+    @MockBean
+    BoardService boardService;
+
+    @MockBean
+    MemberService memberService;
+
+
+    @Test
+    @DisplayName("관리자는 일반회원 자료에 접근 가능하다.")
+    @WithMockUser(roles = "ADMIN")
+    public void adminCanAccessToResourceForBasicMember() throws Exception {
+        공지사항_게시판_접근();
+    }
+
+    @Test
+    @DisplayName("회장은 일반회원 자료에 접근 가능하다.")
+    @WithMockUser(roles = "CHIEF")
+    public void chiefCanAccessToResourceForBasicMember() throws Exception {
+        공지사항_게시판_접근();
+    }
+
+    @Test
+    @DisplayName("회장단은 일반회원 자료에 접근 가능하다.")
+    @WithMockUser(roles = "EXECUTIVES")
+    public void executivesCanAccessToResourceForBasicMember() throws Exception {
+        공지사항_게시판_접근();
+    }
+
+    @Test
+    @DisplayName("일반회원은 일반회원 자료에 접근 가능하다.")
+    @WithMockUser(roles = "BASIC_MEMBER")
+    public void basicMemberCanAccessToResourceForBasicMember() throws Exception {
+        공지사항_게시판_접근();
+    }
+
+    @Test
+    @DisplayName("비활동회원은 일반회원 자료에 접근 불가능하다.")
+    @WithMockUser(roles = "DEACTIVATED_MEMBER")
+    public void deactivatedMemberCannotAccessToResourceForBasicMember() throws Exception {
+        공지사항_게시판_접근_불가();
+    }
+
+    @Test
+    @DisplayName("미승인회원은 일반회원 자료에 접근 불가능하다.")
+    @WithMockUser(roles = "NOT_APPROVED_MEMBER")
+    public void notApprovedMemberCannotAccessToResourceForBasicMember() throws Exception {
+        공지사항_게시판_접근_불가();
+    }
+
+    @Test
+    @DisplayName("비회원은 일반회원 자료에 접근 불가능하다.")
+    @WithMockUser(roles = "ANONYMOUS")
+    public void anonymousCannotAccessToResourceForBasicMember() throws Exception {
+        공지사항_게시판_접근_불가();
+    }
+
+
+    private void 공지사항_게시판_접근() throws Exception {
+        mockMvc.perform(get("/board/all")
+                        .param("menuId", "6"))
+                .andExpect(status().isOk());
+    }
+
+    private void 공지사항_게시판_접근_불가() throws Exception {
+        mockMvc.perform(get("/board/all")
+                        .param("menuId", "6"))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/resource-server/src/test/java/com/inhabas/testConfig/DefaultWebMvcTest.java
+++ b/resource-server/src/test/java/com/inhabas/testConfig/DefaultWebMvcTest.java
@@ -1,5 +1,6 @@
 package com.inhabas.testConfig;
 
+import com.inhabas.api.domain.member.security.DefaultRoleHierarchy;
 import org.springframework.boot.autoconfigure.security.oauth2.client.servlet.OAuth2ClientAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
@@ -22,7 +23,7 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @ActiveProfiles("test") // for disable cloud config & security filter chain
 @WebMvcTest(excludeAutoConfiguration = {OAuth2ClientAutoConfiguration.class}) // disable autoload OAuth2-Client-Components from test properties
-@Import(InterceptorConfigMockBean.class)
+@Import({InterceptorConfigMockBean.class, DefaultRoleHierarchy.class, TestConfigurationForSecurity.class})
 public @interface DefaultWebMvcTest {
     @AliasFor(annotation = WebMvcTest.class, attribute = "value")
     Class<?>[] value() default {};

--- a/resource-server/src/test/java/com/inhabas/testConfig/DefaultWebMvcTest.java
+++ b/resource-server/src/test/java/com/inhabas/testConfig/DefaultWebMvcTest.java
@@ -21,7 +21,7 @@ import java.lang.annotation.Target;
  */
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
-@ActiveProfiles("test") // for disable cloud config & security filter chain
+@ActiveProfiles("default_mvc_test") // for disable cloud config & security filter chain
 @WebMvcTest(excludeAutoConfiguration = {OAuth2ClientAutoConfiguration.class}) // disable autoload OAuth2-Client-Components from test properties
 @Import({InterceptorConfigMockBean.class, DefaultRoleHierarchy.class, TestConfigurationForSecurity.class})
 public @interface DefaultWebMvcTest {

--- a/resource-server/src/test/java/com/inhabas/testConfig/NoSecureWebMvcTest.java
+++ b/resource-server/src/test/java/com/inhabas/testConfig/NoSecureWebMvcTest.java
@@ -20,7 +20,7 @@ import java.lang.annotation.Target;
  */
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
-@ActiveProfiles("test") // for disable cloud config & security filter chain
+@ActiveProfiles("no_security_mvc_test") // for disable cloud config & security filter chain
 @WebMvcTest(excludeAutoConfiguration = {SecurityAutoConfiguration.class, OAuth2ClientAutoConfiguration.class}) // disable default spring-security configuration
 @Import(InterceptorConfigMockBean.class)
 public @interface NoSecureWebMvcTest {

--- a/resource-server/src/test/java/com/inhabas/testConfig/TestConfigurationForSecurity.java
+++ b/resource-server/src/test/java/com/inhabas/testConfig/TestConfigurationForSecurity.java
@@ -1,0 +1,14 @@
+package com.inhabas.testConfig;
+
+import com.inhabas.api.auth.domain.token.jwtUtils.JwtTokenProvider;
+import com.inhabas.api.auth.domain.token.securityFilter.UserPrincipalService;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@TestConfiguration
+public class TestConfigurationForSecurity {
+    @MockBean
+    JwtTokenProvider tokenProvider;
+    @MockBean
+    UserPrincipalService userPrincipalService;
+}


### PR DESCRIPTION
`ADMIN` > `EXECUTIVES` > `BASIC_MEMBER` > `DEACTIVED_MEMBER` > `NOT_APPROVED_MEMBER ` 순으로 권한 적용
`ANONYMOUS` 는 계층 적용을 받지 않음. 회원가입에만 유효한 권한. 다른 권한으로 회원가입 시도 불가능

issue : #95 