### PR TITLE
[refactor/#119] DDD를 지키도록 게시글 도메인과 메뉴 도메인 분리

### DIFF
--- a/resource-server/src/main/java/com/inhabas/api/controller/BoardController.java
+++ b/resource-server/src/main/java/com/inhabas/api/controller/BoardController.java
@@ -1,24 +1,31 @@
 package com.inhabas.api.controller;
 
-import com.inhabas.api.web.argumentResolver.Authenticated;
 import com.inhabas.api.domain.member.MemberId;
+import com.inhabas.api.domain.menu.MenuId;
 import com.inhabas.api.dto.board.BoardDto;
 import com.inhabas.api.dto.board.SaveBoardDto;
 import com.inhabas.api.dto.board.UpdateBoardDto;
 import com.inhabas.api.service.board.BoardService;
+import com.inhabas.api.web.argumentResolver.Authenticated;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import javax.validation.Valid;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 
 @Slf4j
@@ -50,7 +57,7 @@ public class BoardController {
         })
     public ResponseEntity<Page<BoardDto>> getBoardList(
             Pageable pageable,
-            @RequestParam Integer menuId) {
+            @RequestParam MenuId menuId) {
         return new ResponseEntity<>(boardService.getBoardList(menuId, pageable), HttpStatus.OK);
     }
 

--- a/resource-server/src/main/java/com/inhabas/api/controller/ContestBoardController.java
+++ b/resource-server/src/main/java/com/inhabas/api/controller/ContestBoardController.java
@@ -1,5 +1,6 @@
 package com.inhabas.api.controller;
 
+import com.inhabas.api.domain.menu.MenuId;
 import com.inhabas.api.web.argumentResolver.Authenticated;
 import com.inhabas.api.domain.member.MemberId;
 import com.inhabas.api.dto.contest.DetailContestBoardDto;
@@ -44,7 +45,7 @@ public class ContestBoardController {
             @ApiResponse(responseCode = "400", description = "잘못된 게시글 목록 조회 URL 요청"),
             @ApiResponse(responseCode = "403", description = "클라이언트의 접근 권한이 없음")
     })
-    public ResponseEntity<Page<ListContestBoardDto>> getBoardList(@RequestParam Integer menuId, Pageable pageable) {
+    public ResponseEntity<Page<ListContestBoardDto>> getBoardList(@RequestParam MenuId menuId, Pageable pageable) {
         return new ResponseEntity<>(boardService.getBoardList(menuId, pageable), HttpStatus.OK);
     }
 

--- a/resource-server/src/main/java/com/inhabas/api/controller/MenuController.java
+++ b/resource-server/src/main/java/com/inhabas/api/controller/MenuController.java
@@ -1,5 +1,6 @@
 package com.inhabas.api.controller;
 
+import com.inhabas.api.domain.menu.MenuId;
 import com.inhabas.api.dto.menu.MenuDto;
 import com.inhabas.api.dto.menu.MenuGroupDto;
 import com.inhabas.api.service.menu.MenuService;
@@ -35,7 +36,7 @@ public class MenuController {
             @ApiResponse(responseCode = "204"),
             @ApiResponse(responseCode = "400", description = "존재하지 않는 메뉴")
     })
-    public ResponseEntity<MenuDto> getMenuInfo(@RequestParam Integer menuId) {
+    public ResponseEntity<MenuDto> getMenuInfo(@RequestParam MenuId menuId) {
         MenuDto menu = menuService.getMenuInfoById(menuId);
 
         return ResponseEntity.ok(menu);

--- a/resource-server/src/main/java/com/inhabas/api/domain/board/NormalBoard.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/board/NormalBoard.java
@@ -6,14 +6,31 @@ import com.inhabas.api.domain.board.type.wrapper.Title;
 import com.inhabas.api.domain.comment.Comment;
 import com.inhabas.api.domain.file.BoardFile;
 import com.inhabas.api.domain.member.MemberId;
-import com.inhabas.api.domain.menu.Menu;
+import com.inhabas.api.domain.menu.MenuId;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import javax.persistence.AttributeOverride;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.DiscriminatorColumn;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
-import javax.persistence.*;
-import java.util.*;
 
 
 @Entity
@@ -35,9 +52,9 @@ public class NormalBoard extends BaseEntity {
     @Embedded
     protected Contents contents;
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "menu_id", foreignKey = @ForeignKey(name = "fk_board_to_menu"))
-    protected Menu menu;
+    @Embedded
+    @AttributeOverride(name = "id", column = @Column(name = "menu_id"))
+    protected MenuId menuId;
 
     @Embedded
     @AttributeOverride(name = "id", column = @Column(name = "writer_id"))
@@ -77,8 +94,8 @@ public class NormalBoard extends BaseEntity {
         return contents.getValue();
     }
 
-    public Menu getMenu() {
-        return menu;
+    public MenuId getMenuId() {
+        return menuId;
     }
 
     public MemberId getWriterId() {
@@ -124,8 +141,8 @@ public class NormalBoard extends BaseEntity {
     }
 
     @SuppressWarnings("unchecked")
-    public <T extends NormalBoard> T inMenu(Menu menu) {
-        this.menu = menu;
+    public <T extends NormalBoard> T inMenu(MenuId menuId) {
+        this.menuId = menuId;
         return (T) this;
     }
 }

--- a/resource-server/src/main/java/com/inhabas/api/domain/board/NormalBoardRepositoryCustom.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/board/NormalBoardRepositoryCustom.java
@@ -1,14 +1,13 @@
 package com.inhabas.api.domain.board;
 
+import com.inhabas.api.domain.menu.MenuId;
 import com.inhabas.api.dto.board.BoardDto;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface NormalBoardRepositoryCustom {
 
-    Page<BoardDto> findAllByMenuId(Integer menuId, Pageable pageable);
+    Page<BoardDto> findAllByMenuId(MenuId menuId, Pageable pageable);
     Optional<BoardDto> findDtoById(Integer id);
 }

--- a/resource-server/src/main/java/com/inhabas/api/domain/board/NormalBoardRepositoryImpl.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/board/NormalBoardRepositoryImpl.java
@@ -1,20 +1,20 @@
 package com.inhabas.api.domain.board;
 
+import static com.inhabas.api.domain.board.QNormalBoard.normalBoard;
+import static com.inhabas.api.domain.member.QMember.member;
+
+import com.inhabas.api.domain.menu.MenuId;
 import com.inhabas.api.dto.board.BoardDto;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
-
-import java.util.List;
-import java.util.Optional;
-
-import static com.inhabas.api.domain.board.QNormalBoard.normalBoard;
-import static com.inhabas.api.domain.member.QMember.member;
 
 @RequiredArgsConstructor
 public class NormalBoardRepositoryImpl implements NormalBoardRepositoryCustom {
@@ -22,13 +22,13 @@ public class NormalBoardRepositoryImpl implements NormalBoardRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<BoardDto> findAllByMenuId(Integer menuId, Pageable pageable) {
+    public Page<BoardDto> findAllByMenuId(MenuId menuId, Pageable pageable) {
         List<BoardDto> results = queryFactory.select(Projections.constructor(BoardDto.class,
                         normalBoard.id,
                         normalBoard.title.value,
                         Expressions.asString("").as("contents"),
                         member.name.value,
-                        Expressions.asNumber(menuId).as("menuId"),
+                        normalBoard.menuId,
                         normalBoard.created,
                         normalBoard.updated))
                 .from(normalBoard)
@@ -41,8 +41,8 @@ public class NormalBoardRepositoryImpl implements NormalBoardRepositoryCustom {
         return new PageImpl<>(results, pageable, results.size());
     }
 
-    private BooleanExpression menuEq(Integer categoryId) {
-        return normalBoard.menu.id.eq(categoryId);
+    private BooleanExpression menuEq(MenuId menuId) {
+        return normalBoard.menuId.eq(menuId);
     }
 
     @Override
@@ -53,7 +53,7 @@ public class NormalBoardRepositoryImpl implements NormalBoardRepositoryCustom {
                         normalBoard.title.value,
                         normalBoard.contents.value,
                         member.name.value,
-                        normalBoard.menu.id,
+                        normalBoard.menuId,
                         normalBoard.created,
                         normalBoard.updated))
                 .from(normalBoard)

--- a/resource-server/src/main/java/com/inhabas/api/domain/contest/ContestBoardRepositoryCustom.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/contest/ContestBoardRepositoryCustom.java
@@ -1,5 +1,6 @@
 package com.inhabas.api.domain.contest;
 
+import com.inhabas.api.domain.menu.MenuId;
 import com.inhabas.api.dto.contest.DetailContestBoardDto;
 import com.inhabas.api.dto.contest.ListContestBoardDto;
 import org.springframework.data.domain.Page;
@@ -11,6 +12,6 @@ public interface ContestBoardRepositoryCustom {
 
     Optional<DetailContestBoardDto> findDtoById(Integer id);
 
-    Page<ListContestBoardDto> findAllByMenuId(Integer menuId, Pageable pageable);
+    Page<ListContestBoardDto> findAllByMenuId(MenuId menuId, Pageable pageable);
 
 }

--- a/resource-server/src/main/java/com/inhabas/api/domain/contest/ContestBoardRepositoryImpl.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/contest/ContestBoardRepositoryImpl.java
@@ -4,6 +4,7 @@ package com.inhabas.api.domain.contest;
 import static com.inhabas.api.domain.contest.QContestBoard.contestBoard;
 import static com.inhabas.api.domain.member.QMember.member;
 
+import com.inhabas.api.domain.menu.MenuId;
 import com.inhabas.api.dto.contest.DetailContestBoardDto;
 import com.inhabas.api.dto.contest.ListContestBoardDto;
 import com.querydsl.core.types.Order;
@@ -80,7 +81,7 @@ public class ContestBoardRepositoryImpl implements ContestBoardRepositoryCustom 
     }
 
     @Override
-    public Page<ListContestBoardDto> findAllByMenuId(Integer menuId, Pageable pageable) {
+    public Page<ListContestBoardDto> findAllByMenuId(MenuId menuId, Pageable pageable) {
         List <OrderSpecifier> ORDERS = getAllOrderSpecifiers(pageable);
         List<ListContestBoardDto> results = queryFactory.select(Projections.constructor(ListContestBoardDto.class,
                         contestBoard.title.value,
@@ -96,8 +97,8 @@ public class ContestBoardRepositoryImpl implements ContestBoardRepositoryCustom 
         return new PageImpl<>(results, pageable, results.size());
     }
 
-    private BooleanExpression menuEq(Integer menuId) {
-        return contestBoard.menu.id.eq(menuId);
+    private BooleanExpression menuEq(MenuId menuId) {
+        return contestBoard.menuId.eq(menuId);
     }
 
 }

--- a/resource-server/src/main/java/com/inhabas/api/domain/menu/Menu.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/menu/Menu.java
@@ -20,7 +20,8 @@ import javax.persistence.*;
                 @Index(name = "priority_index", columnList = "priority ASC")})
 public class Menu extends BaseEntity {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
@@ -54,5 +55,9 @@ public class Menu extends BaseEntity {
         this.type = type;
         this.name = new MenuName(name);
         this.description = new Description(description);
+    }
+
+    public MenuId getId() {
+        return new MenuId(this.id);
     }
 }

--- a/resource-server/src/main/java/com/inhabas/api/domain/menu/MenuId.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/menu/MenuId.java
@@ -1,0 +1,47 @@
+package com.inhabas.api.domain.menu;
+
+import java.io.Serializable;
+import java.util.Objects;
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MenuId implements Serializable {
+
+    private static final long serialVersionUID = -7661257651938513762L;
+
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Integer id;
+
+    public MenuId(Integer id) {
+        this.id = id;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        MenuId menuId = (MenuId) o;
+        return id.equals(menuId.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(this.id);
+    }
+}

--- a/resource-server/src/main/java/com/inhabas/api/domain/menu/MenuRepositoryCustom.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/menu/MenuRepositoryCustom.java
@@ -2,7 +2,10 @@ package com.inhabas.api.domain.menu;
 
 import com.inhabas.api.dto.menu.MenuGroupDto;
 import java.util.List;
+import java.util.Optional;
 
 public interface MenuRepositoryCustom {
     List<MenuGroupDto> findAllMenuByMenuGroup();
+
+    Optional<Menu> findById(MenuId menuId);
 }

--- a/resource-server/src/main/java/com/inhabas/api/domain/menu/MenuRepositoryImpl.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/menu/MenuRepositoryImpl.java
@@ -1,17 +1,17 @@
 package com.inhabas.api.domain.menu;
 
+import static com.inhabas.api.domain.menu.QMenu.menu;
+import static com.querydsl.core.group.GroupBy.list;
+
 import com.inhabas.api.dto.menu.MenuDto;
 import com.inhabas.api.dto.menu.MenuGroupDto;
 import com.querydsl.core.group.GroupBy;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import lombok.RequiredArgsConstructor;
-
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
-
-import static com.inhabas.api.domain.menu.QMenu.menu;
-import static com.querydsl.core.group.GroupBy.list;
+import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class MenuRepositoryImpl implements MenuRepositoryCustom {
@@ -33,5 +33,13 @@ public class MenuRepositoryImpl implements MenuRepositoryCustom {
                 ).entrySet().stream()
                 .map(entry -> new MenuGroupDto(entry.getKey().getId(), entry.getKey().getName(), entry.getValue()))
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public Optional<Menu> findById(MenuId menuId) {
+        return Optional.ofNullable(
+                jpaQueryFactory.selectFrom(menu)
+                .where(menu.id.eq(Integer.parseInt(menuId.toString())))
+                .fetchOne());
     }
 }

--- a/resource-server/src/main/java/com/inhabas/api/dto/board/BoardDto.java
+++ b/resource-server/src/main/java/com/inhabas/api/dto/board/BoardDto.java
@@ -1,6 +1,7 @@
 package com.inhabas.api.dto.board;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.inhabas.api.domain.menu.MenuId;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -13,7 +14,7 @@ public class BoardDto {
     private String title;
     private String contents;
     private String writerName;
-    private Integer menuId;
+    private MenuId menuId;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern="yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime created;

--- a/resource-server/src/main/java/com/inhabas/api/dto/board/SaveBoardDto.java
+++ b/resource-server/src/main/java/com/inhabas/api/dto/board/SaveBoardDto.java
@@ -1,13 +1,12 @@
 package com.inhabas.api.dto.board;
 
+import com.inhabas.api.domain.menu.MenuId;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.validator.constraints.Length;
-
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -20,9 +19,9 @@ public class SaveBoardDto {
     private String contents;
 
     @NotNull
-    private Integer menuId;
+    private MenuId menuId;
 
-    public SaveBoardDto(String title, String contents, Integer menuId) {
+    public SaveBoardDto(String title, String contents, MenuId menuId) {
         this.title = title;
         this.contents = contents;
         this.menuId = menuId;

--- a/resource-server/src/main/java/com/inhabas/api/dto/menu/MenuDto.java
+++ b/resource-server/src/main/java/com/inhabas/api/dto/menu/MenuDto.java
@@ -1,13 +1,14 @@
 package com.inhabas.api.dto.menu;
 
 import com.inhabas.api.domain.menu.Menu;
+import com.inhabas.api.domain.menu.MenuId;
 import com.inhabas.api.domain.menu.wrapper.MenuType;
 import lombok.Getter;
 
 @Getter
 public class MenuDto {
 
-    private Integer id;
+    private MenuId id;
 
     private Integer priority;
 
@@ -17,8 +18,17 @@ public class MenuDto {
 
     private String description;
 
-    public MenuDto(Integer id, Integer priority, String name, MenuType type, String description) {
+    public MenuDto(MenuId id, Integer priority, String name, MenuType type, String description) {
         this.id = id;
+        this.priority = priority;
+        this.name = name;
+        this.type = type.toString();
+        this.description = description;
+    }
+
+
+    public MenuDto(Integer id, Integer priority, String name, MenuType type, String description) {
+        this.id = new MenuId(id);
         this.priority = priority;
         this.name = name;
         this.type = type.toString();

--- a/resource-server/src/main/java/com/inhabas/api/service/board/BoardService.java
+++ b/resource-server/src/main/java/com/inhabas/api/service/board/BoardService.java
@@ -1,6 +1,7 @@
 package com.inhabas.api.service.board;
 
 import com.inhabas.api.domain.member.MemberId;
+import com.inhabas.api.domain.menu.MenuId;
 import com.inhabas.api.dto.board.BoardDto;
 import com.inhabas.api.dto.board.SaveBoardDto;
 import com.inhabas.api.dto.board.UpdateBoardDto;
@@ -16,6 +17,6 @@ public interface BoardService {
 
     BoardDto getBoard(Integer boardId);
 
-    Page<BoardDto> getBoardList(Integer menuId, Pageable pageable);
+    Page<BoardDto> getBoardList(MenuId menuId, Pageable pageable);
 
 }

--- a/resource-server/src/main/java/com/inhabas/api/service/board/BoardServiceImpl.java
+++ b/resource-server/src/main/java/com/inhabas/api/service/board/BoardServiceImpl.java
@@ -4,18 +4,16 @@ import com.inhabas.api.domain.board.BoardNotFoundException;
 import com.inhabas.api.domain.board.NormalBoard;
 import com.inhabas.api.domain.board.NormalBoardRepository;
 import com.inhabas.api.domain.member.MemberId;
-import com.inhabas.api.domain.menu.Menu;
-import com.inhabas.api.domain.menu.MenuRepository;
+import com.inhabas.api.domain.menu.MenuId;
 import com.inhabas.api.dto.board.BoardDto;
 import com.inhabas.api.dto.board.SaveBoardDto;
 import com.inhabas.api.dto.board.UpdateBoardDto;
+import javax.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-
-import javax.transaction.Transactional;
 
 @Service
 @Slf4j
@@ -24,14 +22,12 @@ import javax.transaction.Transactional;
 public class BoardServiceImpl implements BoardService {
 
     private final NormalBoardRepository boardRepository;
-    private final MenuRepository menuRepository;
 
     @Override
     public Integer write(MemberId memberId, SaveBoardDto saveBoardDto) {
 
-        Menu menu = menuRepository.getById(saveBoardDto.getMenuId());
         NormalBoard normalBoard = new NormalBoard(saveBoardDto.getTitle(), saveBoardDto.getContents())
-                .inMenu(menu)
+                .inMenu(saveBoardDto.getMenuId())
                 .writtenBy(memberId);
 
         return boardRepository.save(normalBoard).getId();
@@ -44,7 +40,7 @@ public class BoardServiceImpl implements BoardService {
                 .orElseThrow(BoardNotFoundException::new);
         NormalBoard updatedBoard = new NormalBoard(updateBoardDto.getId(), updateBoardDto.getTitle(), updateBoardDto.getContents())
                 .writtenBy(memberId)
-                .inMenu(savedBoard.getMenu());
+                .inMenu(savedBoard.getMenuId());
 
         return boardRepository.save(updatedBoard).getId();
     }
@@ -61,7 +57,7 @@ public class BoardServiceImpl implements BoardService {
     }
 
     @Override
-    public Page<BoardDto> getBoardList(Integer menuId, Pageable pageable) {
+    public Page<BoardDto> getBoardList(MenuId menuId, Pageable pageable) {
             return boardRepository.findAllByMenuId(menuId, pageable);
     }
 }

--- a/resource-server/src/main/java/com/inhabas/api/service/contest/ContestBoardService.java
+++ b/resource-server/src/main/java/com/inhabas/api/service/contest/ContestBoardService.java
@@ -1,6 +1,7 @@
 package com.inhabas.api.service.contest;
 
 import com.inhabas.api.domain.member.MemberId;
+import com.inhabas.api.domain.menu.MenuId;
 import com.inhabas.api.dto.contest.DetailContestBoardDto;
 import com.inhabas.api.dto.contest.ListContestBoardDto;
 import com.inhabas.api.dto.contest.SaveContestBoardDto;
@@ -17,6 +18,6 @@ public interface ContestBoardService {
 
     DetailContestBoardDto getBoard(Integer id);
 
-    Page<ListContestBoardDto> getBoardList(Integer menuId, Pageable pageable);
+    Page<ListContestBoardDto> getBoardList(MenuId menuId, Pageable pageable);
 
 }

--- a/resource-server/src/main/java/com/inhabas/api/service/contest/ContestBoardServiceImpl.java
+++ b/resource-server/src/main/java/com/inhabas/api/service/contest/ContestBoardServiceImpl.java
@@ -4,7 +4,7 @@ import com.inhabas.api.domain.board.BoardNotFoundException;
 import com.inhabas.api.domain.contest.ContestBoard;
 import com.inhabas.api.domain.contest.ContestBoardRepository;
 import com.inhabas.api.domain.member.MemberId;
-import com.inhabas.api.domain.member.MemberRepository;
+import com.inhabas.api.domain.menu.MenuId;
 import com.inhabas.api.dto.contest.DetailContestBoardDto;
 import com.inhabas.api.dto.contest.ListContestBoardDto;
 import com.inhabas.api.dto.contest.SaveContestBoardDto;
@@ -54,7 +54,7 @@ public class ContestBoardServiceImpl implements ContestBoardService {
                 .deadline(dto.getDeadline())
                 .build()
                 .writtenBy(memberId)
-                .inMenu(savedContestBoard.getMenu());
+                .inMenu(savedContestBoard.getMenuId());
 
         return contestBoardRepository.save(entity).getId();
     }
@@ -72,7 +72,7 @@ public class ContestBoardServiceImpl implements ContestBoardService {
     }
 
     @Override
-    public Page<ListContestBoardDto> getBoardList(Integer menuId, Pageable pageable) {
+    public Page<ListContestBoardDto> getBoardList(MenuId menuId, Pageable pageable) {
         return contestBoardRepository.findAllByMenuId(menuId, pageable);
     }
 }

--- a/resource-server/src/main/java/com/inhabas/api/service/menu/MenuService.java
+++ b/resource-server/src/main/java/com/inhabas/api/service/menu/MenuService.java
@@ -1,5 +1,6 @@
 package com.inhabas.api.service.menu;
 
+import com.inhabas.api.domain.menu.MenuId;
 import com.inhabas.api.dto.menu.MenuDto;
 import com.inhabas.api.dto.menu.MenuGroupDto;
 
@@ -9,5 +10,5 @@ public interface MenuService {
 
     List<MenuGroupDto> getAllMenuInfo();
 
-    MenuDto getMenuInfoById(Integer menuId);
+    MenuDto getMenuInfoById(MenuId menuId);
 }

--- a/resource-server/src/main/java/com/inhabas/api/service/menu/MenuServiceImpl.java
+++ b/resource-server/src/main/java/com/inhabas/api/service/menu/MenuServiceImpl.java
@@ -1,6 +1,7 @@
 package com.inhabas.api.service.menu;
 
 import com.inhabas.api.domain.menu.Menu;
+import com.inhabas.api.domain.menu.MenuId;
 import com.inhabas.api.domain.menu.MenuRepository;
 import com.inhabas.api.dto.menu.MenuDto;
 import com.inhabas.api.dto.menu.MenuGroupDto;
@@ -24,7 +25,7 @@ public class MenuServiceImpl implements MenuService {
 
     @Override
     @Transactional(readOnly = true)
-    public MenuDto getMenuInfoById(Integer menuId) {
+    public MenuDto getMenuInfoById(MenuId menuId) {
 
         Menu menu = menuRepository.findById(menuId)
                 .orElseThrow(MenuNotExistException::new);

--- a/resource-server/src/main/java/com/inhabas/api/web/converter/MemberIdConverter.java
+++ b/resource-server/src/main/java/com/inhabas/api/web/converter/MemberIdConverter.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component;
 public class MemberIdConverter {
 
     @Component
-    public static class StringToEventConverter implements Converter<String, MemberId> {
+    public static class StringToMemberIdConverter implements Converter<String, MemberId> {
         @Override
         public MemberId convert(String source){
             return new MemberId(Integer.parseInt(source));
@@ -15,7 +15,7 @@ public class MemberIdConverter {
     }
 
     @Component
-    public static class IntegerToEventConverter implements Converter<Integer, MemberId> {
+    public static class IntegerToMemberIdConverter implements Converter<Integer, MemberId> {
         @Override
         public MemberId convert(Integer source){
             return new MemberId(source);
@@ -23,7 +23,7 @@ public class MemberIdConverter {
     }
 
     @Component
-    public static class EventToStringConverter implements Converter<MemberId, String>{
+    public static class MemberIdToStringConverter implements Converter<MemberId, String>{
         @Override
         public String convert(MemberId source){
             return source.toString();

--- a/resource-server/src/main/java/com/inhabas/api/web/converter/MenuIdConverter.java
+++ b/resource-server/src/main/java/com/inhabas/api/web/converter/MenuIdConverter.java
@@ -1,0 +1,25 @@
+package com.inhabas.api.web.converter;
+
+import com.inhabas.api.domain.menu.MenuId;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+public class MenuIdConverter {
+
+    @Component
+    public static class StringToMenuIdConverter implements Converter<String, MenuId> {
+        @Override
+        public MenuId convert(String source){
+            return new MenuId(Integer.parseInt(source));
+        }
+    }
+
+    @Component
+    public static class MenuIdToStringConverter implements Converter<MenuId, String>{
+        @Override
+        public String convert(MenuId source){
+            return source.toString();
+        }
+    }
+
+}

--- a/resource-server/src/test/java/com/inhabas/api/controller/ContestBoardControllerTest.java
+++ b/resource-server/src/test/java/com/inhabas/api/controller/ContestBoardControllerTest.java
@@ -1,5 +1,17 @@
 package com.inhabas.api.controller;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.inhabas.annotataion.WithMockJwtAuthenticationToken;
 import com.inhabas.api.dto.contest.DetailContestBoardDto;
@@ -8,7 +20,11 @@ import com.inhabas.api.dto.contest.SaveContestBoardDto;
 import com.inhabas.api.dto.contest.UpdateContestBoardDto;
 import com.inhabas.api.service.contest.ContestBoardService;
 import com.inhabas.testConfig.DefaultWebMvcTest;
-import org.junit.jupiter.api.BeforeEach;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,49 +33,21 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.servlet.view.json.MappingJackson2JsonView;
-
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doNothing;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @DefaultWebMvcTest(ContestBoardController.class)
 public class ContestBoardControllerTest {
 
+    @Autowired
     private MockMvc mvc;
 
     @Autowired
     private ObjectMapper objectMapper;
 
-    @Autowired
-    private ContestBoardController contestBoardController;
-
     @MockBean
     private ContestBoardService contestBoardService;
 
-    @BeforeEach
-    public void setUp() {
-        mvc = MockMvcBuilders
-                .standaloneSetup(contestBoardController)
-                .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver())
-                .setViewResolvers((viewName, locale) -> new MappingJackson2JsonView())
-                .build();
-    }
 
     @DisplayName("공모전 게시글 저장을 요청한다.")
     @Test
@@ -118,11 +106,12 @@ public class ContestBoardControllerTest {
 
         Page<ListContestBoardDto> expectedContestBoardDto = new PageImpl<>(results, pageable, results.size());
 
-        given(contestBoardService.getBoardList(anyInt(), any())).willReturn(expectedContestBoardDto);
+        given(contestBoardService.getBoardList(any(), any())).willReturn(expectedContestBoardDto);
 
         // when
         String responseBody = mvc.perform(get("/contest/all")
                         .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
                         .param("menuId", "9")
                         .param("page", "0")
                         .param("size", "10")

--- a/resource-server/src/test/java/com/inhabas/api/controller/MenuControllerTest.java
+++ b/resource-server/src/test/java/com/inhabas/api/controller/MenuControllerTest.java
@@ -1,24 +1,24 @@
 package com.inhabas.api.controller;
 
-import com.inhabas.api.domain.menu.wrapper.MenuType;
-import com.inhabas.api.dto.menu.MenuDto;
-import com.inhabas.api.dto.menu.MenuGroupDto;
-import com.inhabas.api.service.menu.MenuService;
-import com.inhabas.testConfig.NoSecureWebMvcTest;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.web.servlet.MockMvc;
-
-import java.util.List;
-
-import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.inhabas.api.domain.menu.MenuId;
+import com.inhabas.api.domain.menu.wrapper.MenuType;
+import com.inhabas.api.dto.menu.MenuDto;
+import com.inhabas.api.dto.menu.MenuGroupDto;
+import com.inhabas.api.service.menu.MenuService;
+import com.inhabas.testConfig.NoSecureWebMvcTest;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
 
 @NoSecureWebMvcTest(MenuController.class)
 public class MenuControllerTest {
@@ -33,7 +33,7 @@ public class MenuControllerTest {
     @Test
     public void getTotalMenuInfoTest() throws Exception {
         given(menuService.getAllMenuInfo()).willReturn(
-                List.of(new MenuGroupDto(1, "IBAS", List.of(new MenuDto(1,1,"동아리 소개", MenuType.INTRODUCE, "")))));
+                List.of(new MenuGroupDto(1, "IBAS", List.of(new MenuDto(new MenuId(1),1,"동아리 소개", MenuType.INTRODUCE, "")))));
 
         mvc.perform(get("/menu/all"))
                 .andExpect(status().isOk())
@@ -46,15 +46,15 @@ public class MenuControllerTest {
     @Test
     public void getMenuInfoByIdTest() throws Exception {
 
-        given(menuService.getMenuInfoById(anyInt())).willReturn(
-                new MenuDto(6,1,"공지사항", MenuType.LIST, ""));
+        given(menuService.getMenuInfoById(any())).willReturn(
+                new MenuDto(new MenuId(6),1,"공지사항", MenuType.LIST, ""));
 
         mvc.perform(get("/menu")
                         .param("menuId", "6"))
                 .andExpect(status().isOk())
                 .andReturn();
 
-        then(menuService).should(times(1)).getMenuInfoById(anyInt());
+        then(menuService).should(times(1)).getMenuInfoById(any());
     }
 
 }

--- a/resource-server/src/test/java/com/inhabas/api/domain/BaseEntityTest.java
+++ b/resource-server/src/test/java/com/inhabas/api/domain/BaseEntityTest.java
@@ -1,5 +1,8 @@
 package com.inhabas.api.domain;
 
+import static com.inhabas.api.domain.MemberTest.MEMBER1;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.inhabas.api.config.JpaConfig;
 import com.inhabas.api.domain.board.NormalBoard;
 import com.inhabas.api.domain.member.Member;
@@ -7,16 +10,12 @@ import com.inhabas.api.domain.menu.Menu;
 import com.inhabas.api.domain.menu.MenuGroup;
 import com.inhabas.api.domain.menu.wrapper.MenuType;
 import com.inhabas.testConfig.DefaultDataJpaTest;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.annotation.Import;
-
-import java.time.LocalDateTime;
-
-import static com.inhabas.api.domain.MemberTest.MEMBER1;
-import static org.assertj.core.api.Assertions.assertThat;
 
 @DefaultDataJpaTest
 @Import(JpaConfig.class)
@@ -46,7 +45,7 @@ public class BaseEntityTest {
         Member member = em.persist(MEMBER1());
         NormalBoard board = new NormalBoard("title", "contents")
                 .writtenBy(member.getId())
-                .inMenu(freeBoardMenu);
+                .inMenu(freeBoardMenu.getId());
 
         //when
         em.persist(board);
@@ -62,13 +61,13 @@ public class BaseEntityTest {
         Member member = em.persist(MEMBER1());
         NormalBoard board = new NormalBoard("title", "contents")
                 .writtenBy(member.getId())
-                .inMenu(freeBoardMenu);
+                .inMenu(freeBoardMenu.getId());
         em.persist(board);
 
         //when
         NormalBoard param = new NormalBoard(board.getId(), "new title", "new contents")
                 .writtenBy(member.getId())
-                .inMenu(freeBoardMenu);
+                .inMenu(freeBoardMenu.getId());
         em.merge(param);
         em.flush();em.clear();
 

--- a/resource-server/src/test/java/com/inhabas/api/domain/CommentRepositoryTest.java
+++ b/resource-server/src/test/java/com/inhabas/api/domain/CommentRepositoryTest.java
@@ -1,24 +1,24 @@
 package com.inhabas.api.domain;
 
+import static com.inhabas.api.domain.MemberTest.MEMBER1;
+import static com.inhabas.api.domain.MemberTest.MEMBER2;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.inhabas.api.domain.board.NormalBoard;
 import com.inhabas.api.domain.comment.Comment;
 import com.inhabas.api.domain.comment.CommentRepository;
 import com.inhabas.api.domain.member.Member;
-
 import com.inhabas.api.domain.menu.Menu;
 import com.inhabas.api.domain.menu.MenuGroup;
 import com.inhabas.api.domain.menu.wrapper.MenuType;
 import com.inhabas.api.dto.comment.CommentDetailDto;
 import com.inhabas.testConfig.DefaultDataJpaTest;
-import org.junit.jupiter.api.*;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
-
-import java.util.List;
-
-import static com.inhabas.api.domain.MemberTest.MEMBER1;
-import static com.inhabas.api.domain.MemberTest.MEMBER2;
-import static org.assertj.core.api.Assertions.assertThat;
 
 @DefaultDataJpaTest
 public class CommentRepositoryTest {
@@ -49,7 +49,7 @@ public class CommentRepositoryTest {
         normalBoard = em.persist(
                 NormalBoardTest.getBoard1()
                         .writtenBy(writer.getId())
-                        .inMenu(freeBoardMenu)
+                        .inMenu(freeBoardMenu.getId())
         );
     }
 

--- a/resource-server/src/test/java/com/inhabas/api/domain/ContestBoardRepositoryTest.java
+++ b/resource-server/src/test/java/com/inhabas/api/domain/ContestBoardRepositoryTest.java
@@ -1,5 +1,8 @@
 package com.inhabas.api.domain;
 
+import static com.inhabas.api.domain.MemberTest.MEMBER1;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.inhabas.api.domain.contest.ContestBoard;
 import com.inhabas.api.domain.contest.ContestBoardRepository;
 import com.inhabas.api.domain.member.Member;
@@ -9,6 +12,9 @@ import com.inhabas.api.domain.menu.wrapper.MenuType;
 import com.inhabas.api.dto.contest.DetailContestBoardDto;
 import com.inhabas.api.dto.contest.ListContestBoardDto;
 import com.inhabas.testConfig.DefaultDataJpaTest;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,13 +22,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-
-import static com.inhabas.api.domain.MemberTest.MEMBER1;
-import static org.assertj.core.api.Assertions.*;
 
 @DefaultDataJpaTest
 public class ContestBoardRepositoryTest {
@@ -52,11 +51,11 @@ public class ContestBoardRepositoryTest {
                         .build());
 
         board1 = ContestBoardTest.getContestBoard1()
-                    .writtenBy(writer.getId()).inMenu(menu);
+                    .writtenBy(writer.getId()).inMenu(menu.getId());
         board2 = ContestBoardTest.getContestBoard2()
-                    .writtenBy(writer.getId()).inMenu(menu);
+                    .writtenBy(writer.getId()).inMenu(menu.getId());
         board3 = ContestBoardTest.getContestBoard3()
-                    .writtenBy(writer.getId()).inMenu(menu);
+                    .writtenBy(writer.getId()).inMenu(menu.getId());
     }
 
     @DisplayName("저장한 게시글의 Id를 참조하여 Dto를 반환한다.")

--- a/resource-server/src/test/java/com/inhabas/api/domain/NormalBoardRepositoryTest.java
+++ b/resource-server/src/test/java/com/inhabas/api/domain/NormalBoardRepositoryTest.java
@@ -1,13 +1,21 @@
 package com.inhabas.api.domain;
 
+import static com.inhabas.api.domain.MemberTest.MEMBER1;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import com.inhabas.api.domain.board.NormalBoard;
-import com.inhabas.api.domain.member.Member;
 import com.inhabas.api.domain.board.NormalBoardRepository;
+import com.inhabas.api.domain.member.Member;
 import com.inhabas.api.domain.menu.Menu;
 import com.inhabas.api.domain.menu.MenuGroup;
+import com.inhabas.api.domain.menu.MenuId;
 import com.inhabas.api.domain.menu.wrapper.MenuType;
 import com.inhabas.api.dto.board.BoardDto;
 import com.inhabas.testConfig.DefaultDataJpaTest;
+import java.util.List;
+import javax.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,14 +23,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-
-import javax.persistence.EntityNotFoundException;
-import java.util.List;
-
-import static com.inhabas.api.domain.MemberTest.MEMBER1;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DefaultDataJpaTest
 public class NormalBoardRepositoryTest {
@@ -59,11 +59,11 @@ public class NormalBoardRepositoryTest {
                         .build());
 
         FREE_BOARD = NormalBoardTest.getBoard1()
-                .writtenBy(writer.getId()).inMenu(freeBoardMenu);
+                .writtenBy(writer.getId()).inMenu(freeBoardMenu.getId());
         NOTICE_BOARD = NormalBoardTest.getBoard2()
-                .writtenBy(writer.getId()).inMenu(NoticeBoardMenu);
+                .writtenBy(writer.getId()).inMenu(NoticeBoardMenu.getId());
         NOTICE_BOARD_2 = NormalBoardTest.getBoard3()
-                .writtenBy(writer.getId()).inMenu(NoticeBoardMenu);
+                .writtenBy(writer.getId()).inMenu(NoticeBoardMenu.getId());
     }
 
 
@@ -100,7 +100,7 @@ public class NormalBoardRepositoryTest {
                 () -> assertThat(find.getId()).isEqualTo(FREE_BOARD.getId()),
                 () -> assertThat(find.getTitle()).isEqualTo(FREE_BOARD.getTitle()),
                 () -> assertThat(find.getContents()).isEqualTo(FREE_BOARD.getContents()),
-                () -> assertThat(find.getMenuId()).isEqualTo(FREE_BOARD.getMenu().getId()),
+                () -> assertThat(find.getMenuId()).isEqualTo(FREE_BOARD.getMenuId()),
                 () -> assertThat(find.getWriterName()).isEqualTo(writer.getName())
         );
     }
@@ -160,21 +160,21 @@ public class NormalBoardRepositoryTest {
         boardRepository.save(FREE_BOARD);
         boardRepository.save(NOTICE_BOARD);
         boardRepository.save(NOTICE_BOARD_2);
-        Integer freeBoardId = FREE_BOARD.getMenu().getId();
-        Integer noticeBoardId = NOTICE_BOARD.getMenu().getId();
+        MenuId freeBoardMenuId = FREE_BOARD.getMenuId();
+        MenuId noticeBoardMenuId = NOTICE_BOARD.getMenuId();
 
         //when
-        Page<BoardDto> freeBoards = boardRepository.findAllByMenuId(freeBoardId, Pageable.ofSize(5));
-        Page<BoardDto> noticeBoards = boardRepository.findAllByMenuId(noticeBoardId, Pageable.ofSize(5));
+        Page<BoardDto> freeBoards = boardRepository.findAllByMenuId(freeBoardMenuId, Pageable.ofSize(5));
+        Page<BoardDto> noticeBoards = boardRepository.findAllByMenuId(noticeBoardMenuId, Pageable.ofSize(5));
 
         //then
         assertThat(freeBoards.getTotalElements()).isEqualTo(1);
         freeBoards.forEach(
-                board->assertThat(board.getMenuId()).isEqualTo(freeBoardId));
+                board->assertThat(board.getMenuId()).isEqualTo(freeBoardMenuId));
 
         assertThat(noticeBoards.getTotalElements()).isEqualTo(2);
         noticeBoards.forEach(
-                board->assertThat(board.getMenuId()).isEqualTo(noticeBoardId));
+                board->assertThat(board.getMenuId()).isEqualTo(noticeBoardMenuId));
     }
 
 }

--- a/resource-server/src/test/java/com/inhabas/api/dto/board/SaveBoardDtoTest.java
+++ b/resource-server/src/test/java/com/inhabas/api/dto/board/SaveBoardDtoTest.java
@@ -1,14 +1,17 @@
 package com.inhabas.api.dto.board;
-import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.inhabas.api.domain.menu.MenuId;
+import java.util.Set;
 import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
-import javax.validation.ValidatorFactory;
 import javax.validation.Validator;
-
-import java.util.Set;
-
-import static org.junit.jupiter.api.Assertions.*;
+import javax.validation.ValidatorFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 public class SaveBoardDtoTest {
 
@@ -30,7 +33,7 @@ public class SaveBoardDtoTest {
     @Test
     public void SaveBoardDto_is_OK(){
         //given
-        SaveBoardDto saveBoardDto = new SaveBoardDto("title", "contents", 1);
+        SaveBoardDto saveBoardDto = new SaveBoardDto("title", "contents", new MenuId(1));
 
         //when
         Set<ConstraintViolation<SaveBoardDto>> violations = validator.validate(saveBoardDto);
@@ -43,7 +46,7 @@ public class SaveBoardDtoTest {
     @Test
     public void Contents_is_null() {
         // given
-        SaveBoardDto saveBoardDto = new SaveBoardDto("title", null, 1);
+        SaveBoardDto saveBoardDto = new SaveBoardDto("title", null, new MenuId(1));
 
         // when
         Set<ConstraintViolation<SaveBoardDto>> violations = validator.validate(saveBoardDto);
@@ -60,7 +63,7 @@ public class SaveBoardDtoTest {
         String title = "title".repeat(20) + ".";
         String contents = "그냥 본문 내용입니다.";
 
-        SaveBoardDto saveBoardDto = new SaveBoardDto(title, contents, 1);
+        SaveBoardDto saveBoardDto = new SaveBoardDto(title, contents, new MenuId(1));
 
         // when
         Set<ConstraintViolation<SaveBoardDto>> violations = validator.validate(saveBoardDto);

--- a/resource-server/src/test/java/com/inhabas/api/service/BoardServiceTest.java
+++ b/resource-server/src/test/java/com/inhabas/api/service/BoardServiceTest.java
@@ -1,16 +1,27 @@
 package com.inhabas.api.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.anyInt;
+import static org.mockito.BDDMockito.doNothing;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.times;
+
 import com.inhabas.api.domain.board.NormalBoard;
 import com.inhabas.api.domain.board.NormalBoardRepository;
 import com.inhabas.api.domain.member.Member;
 import com.inhabas.api.domain.member.MemberId;
-import com.inhabas.api.domain.member.MemberRepository;
 import com.inhabas.api.domain.menu.Menu;
-import com.inhabas.api.domain.menu.MenuRepository;
+import com.inhabas.api.domain.menu.MenuId;
 import com.inhabas.api.dto.board.BoardDto;
 import com.inhabas.api.dto.board.SaveBoardDto;
 import com.inhabas.api.dto.board.UpdateBoardDto;
 import com.inhabas.api.service.board.BoardServiceImpl;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
@@ -26,15 +37,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.*;
-
 
 @ExtendWith(MockitoExtension.class)
 public class BoardServiceTest {
@@ -44,12 +46,6 @@ public class BoardServiceTest {
 
     @Mock
     NormalBoardRepository boardRepository;
-
-    @Mock
-    MenuRepository menuRepository;
-
-    @Mock
-    MemberRepository memberRepository;
 
     private MockMvc mockMvc;
 
@@ -62,12 +58,11 @@ public class BoardServiceTest {
     @Test
     public void createBoard() {
         //given
-        SaveBoardDto saveBoardDto = new SaveBoardDto("title", "contents", 1);
+        SaveBoardDto saveBoardDto = new SaveBoardDto("title", "contents", new MenuId(1));
         NormalBoard normalBoard = new NormalBoard(1, "title", "contents");
         Menu menu = new Menu(null, 1, null, "name", "description");
         Member member = new Member(new MemberId(12201863), "mingyeom", "010-0000-0000","my@gmail.com", "picture", null, null);
         given(boardRepository.save(any())).willReturn(normalBoard);
-        given(menuRepository.getById(any())).willReturn(menu);
 
         // when
         Integer returnedId = boardService.write(new MemberId(12201863), saveBoardDto);
@@ -84,8 +79,12 @@ public class BoardServiceTest {
         //given
         PageRequest pageable = PageRequest.of(0,10, Sort.Direction.ASC, "created");
 
-        BoardDto boardDto1 = new BoardDto(1, "title", "contents", "mingyeom",1, LocalDateTime.now(), LocalDateTime.now() );
-        BoardDto boardDto2 = new BoardDto(2, "title", "contents", "minji",1, LocalDateTime.now(), LocalDateTime.now() );
+        BoardDto boardDto1 =
+                new BoardDto(1, "title", "contents", "mingyeom",
+                        new MenuId(1), LocalDateTime.now(), LocalDateTime.now() );
+        BoardDto boardDto2 =
+                new BoardDto(2, "title", "contents", "minji",
+                        new MenuId(1), LocalDateTime.now(), LocalDateTime.now() );
 
         List<BoardDto> results = new ArrayList<>();
         results.add(boardDto1);
@@ -95,7 +94,7 @@ public class BoardServiceTest {
         given(boardRepository.findAllByMenuId(any(), any())).willReturn(expectedBoardDto);
 
         //when
-        Page<BoardDto> returnedBoardList = boardService.getBoardList(1, pageable);
+        Page<BoardDto> returnedBoardList = boardService.getBoardList(new MenuId(1), pageable);
 
         //then
         then(boardRepository).should(times(1)).findAllByMenuId(any(), any());
@@ -106,7 +105,9 @@ public class BoardServiceTest {
     @Test
     public void getDetailBoard() {
         //given
-        BoardDto boardDto = new BoardDto(1, "title", "contents", "김민겸", 1, LocalDateTime.now() , null);
+        BoardDto boardDto =
+                new BoardDto(1, "title", "contents", "김민겸",
+                        new MenuId(1), LocalDateTime.now() , null);
         given(boardRepository.findDtoById(any())).willReturn(Optional.of(boardDto));
 
         // when

--- a/resource-server/src/test/java/com/inhabas/api/service/ContestBoardServiceTest.java
+++ b/resource-server/src/test/java/com/inhabas/api/service/ContestBoardServiceTest.java
@@ -1,15 +1,27 @@
 package com.inhabas.api.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+
 import com.inhabas.api.domain.contest.ContestBoard;
 import com.inhabas.api.domain.contest.ContestBoardRepository;
 import com.inhabas.api.domain.member.Member;
 import com.inhabas.api.domain.member.MemberId;
-import com.inhabas.api.domain.member.MemberRepository;
+import com.inhabas.api.domain.menu.MenuId;
 import com.inhabas.api.dto.contest.DetailContestBoardDto;
 import com.inhabas.api.dto.contest.ListContestBoardDto;
 import com.inhabas.api.dto.contest.SaveContestBoardDto;
 import com.inhabas.api.dto.contest.UpdateContestBoardDto;
 import com.inhabas.api.service.contest.ContestBoardServiceImpl;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,22 +29,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.*;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.times;
 
 @ExtendWith(MockitoExtension.class)
 public class ContestBoardServiceTest {
@@ -104,7 +107,7 @@ public class ContestBoardServiceTest {
         given(contestBoardRepository.findAllByMenuId(any(), any())).willReturn(expectedContestBoardDto);
 
         //when
-        Page<ListContestBoardDto> returnedBoardList = contestBoardService.getBoardList(1, pageable);
+        Page<ListContestBoardDto> returnedBoardList = contestBoardService.getBoardList(new MenuId(1), pageable);
 
         //then
         assertThat(returnedBoardList).isEqualTo(expectedContestBoardDto);

--- a/resource-server/src/test/java/com/inhabas/api/service/MenuServiceTest.java
+++ b/resource-server/src/test/java/com/inhabas/api/service/MenuServiceTest.java
@@ -1,12 +1,21 @@
 package com.inhabas.api.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
 import com.inhabas.api.domain.menu.Menu;
 import com.inhabas.api.domain.menu.MenuGroup;
+import com.inhabas.api.domain.menu.MenuId;
 import com.inhabas.api.domain.menu.MenuRepository;
 import com.inhabas.api.domain.menu.wrapper.MenuType;
 import com.inhabas.api.dto.menu.MenuDto;
 import com.inhabas.api.service.menu.MenuNotExistException;
 import com.inhabas.api.service.menu.MenuServiceImpl;
+import java.util.ArrayList;
+import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,15 +24,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
-
-import java.util.ArrayList;
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.times;
 
 @ExtendWith(MockitoExtension.class)
 public class MenuServiceTest {
@@ -53,13 +53,13 @@ public class MenuServiceTest {
         ReflectionTestUtils.setField(boardGroup, "id", 1);
         Menu existMenu = new Menu(boardGroup, 1, MenuType.LIST, "자유게시판", "자유로운 게시판 입니다.");
         ReflectionTestUtils.setField(existMenu, "id", 1);
-        given(menuRepository.findById(anyInt())).willReturn(Optional.of(existMenu));
+        given(menuRepository.findById(any(MenuId.class))).willReturn(Optional.of(existMenu));
 
         //when
-        MenuDto returnedMenuDto = menuService.getMenuInfoById(1);
+        MenuDto returnedMenuDto = menuService.getMenuInfoById(new MenuId(1));
 
         //then
-        then(menuRepository).should(times(1)).findById(anyInt());
+        then(menuRepository).should(times(1)).findById(any(MenuId.class));
         assertThat(returnedMenuDto)
                 .usingRecursiveComparison()
                 .isEqualTo(MenuDto.convert(existMenu));
@@ -69,10 +69,10 @@ public class MenuServiceTest {
     @Test
     public void FailToGetMenuInfoByIdTest() {
 
-        given(menuRepository.findById(anyInt())).willReturn(Optional.empty());
+        given(menuRepository.findById(any(MenuId.class))).willReturn(Optional.empty());
 
         //when
         Assertions.assertThrows(MenuNotExistException.class,
-                () -> menuService.getMenuInfoById(1));
+                () -> menuService.getMenuInfoById(new MenuId(1)));
     }
 }


### PR DESCRIPTION
게시글 엔티티가 메뉴 엔티티를 직접 참조하고 있었는데, 

두 개의 어그리게이트를 분리하기 위해서

`MenuId 를 참조하도록 함.`

단, `@EmbeddedId` 와 `@GeneratedValue` 는 동시에 사용할 수 없는 문제가 있음. 
(auto_increment key 를 값객체로 직접 사용하기 힘들다는 단점)

따라서 `MenuId` 를 선언해서 다른 모든 곳에서는 MenuId 를 사용.
Menu 엔티티에서는 원시타입 Integer를 사용해서 autoincrement가 적용되게 하였고
getter의 반환타입을 MenuId 로 설정.
따라서 메뉴 도메인 외부에서는 MenuId를 사용하도록 강제함.  

resolve: #119 