### PR TITLE
[feature/#132] 예산 사용 내역 기능 추가

### DIFF
--- a/resource-server/src/main/java/com/inhabas/api/config/WebSecurityConfig.java
+++ b/resource-server/src/main/java/com/inhabas/api/config/WebSecurityConfig.java
@@ -1,8 +1,8 @@
 package com.inhabas.api.config;
 
 import com.inhabas.api.auth.domain.token.securityFilter.TokenAuthenticationProcessingFilter;
-import com.inhabas.api.domain.member.security.Hierarchical;
 import com.inhabas.api.domain.member.domain.valueObject.Role;
+import com.inhabas.api.domain.member.security.Hierarchical;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Profile;
@@ -51,6 +51,9 @@ public class WebSecurityConfig {
                         .antMatchers("/jwt/**").permitAll()
                         .antMatchers(HttpMethod.GET, "/menu/**", "/signUp/schedule", "/member/chief").permitAll()
                         .antMatchers("/signUp/**").hasRole(Role.ANONYMOUS.toString())
+                    // 회계내역
+                        .antMatchers(HttpMethod.GET, "/budget/history/**").permitAll()
+                        .antMatchers("/budget/history/**").hasAuthority("Team_총무")
                         .anyRequest().hasRole(Role.BASIC_MEMBER.toString())
 
                     .expressionHandler(expressionHandler());
@@ -91,6 +94,9 @@ public class WebSecurityConfig {
                         .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
                         .antMatchers("/swagger", "/swagger-ui/**", "/docs/**", "/jwt/**").permitAll()
                         .antMatchers(HttpMethod.GET, "/menu/**", "/signUp/schedule", "/member/chief").permitAll()
+                    // 회계내역
+                        .antMatchers(HttpMethod.GET, "/budget/history/**").permitAll()
+                        .antMatchers("/budget/history/**").hasAuthority("Team_총무")
                         .antMatchers("/signUp/**").hasRole(Role.ANONYMOUS.toString())
                         .anyRequest().hasRole(Role.BASIC_MEMBER.toString());
         }

--- a/resource-server/src/main/java/com/inhabas/api/domain/budget/HistoryCannotModifiableException.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/budget/HistoryCannotModifiableException.java
@@ -1,0 +1,14 @@
+package com.inhabas.api.domain.budget;
+
+import org.springframework.security.access.AccessDeniedException;
+
+public class HistoryCannotModifiableException extends AccessDeniedException {
+
+    public HistoryCannotModifiableException() {
+        super("다른 담당자가 작성한 내역은 수정할 수 없습니다!");
+    }
+
+    public HistoryCannotModifiableException(String msg) {
+        super(msg);
+    }
+}

--- a/resource-server/src/main/java/com/inhabas/api/domain/budget/NotFoundBudgetHistoryException.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/budget/NotFoundBudgetHistoryException.java
@@ -1,0 +1,12 @@
+package com.inhabas.api.domain.budget;
+
+public class NotFoundBudgetHistoryException extends RuntimeException {
+
+    public NotFoundBudgetHistoryException() {
+        super("cannot find such budget history!");
+    }
+
+    public NotFoundBudgetHistoryException(String message) {
+        super(message);
+    }
+}

--- a/resource-server/src/main/java/com/inhabas/api/domain/budget/domain/BudgetHistory.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/budget/domain/BudgetHistory.java
@@ -1,0 +1,95 @@
+package com.inhabas.api.domain.budget.domain;
+
+import com.inhabas.api.domain.BaseEntity;
+import com.inhabas.api.domain.budget.HistoryCannotModifiableException;
+import com.inhabas.api.domain.budget.NotFoundBudgetHistoryException;
+import com.inhabas.api.domain.member.domain.valueObject.MemberId;
+import java.time.LocalDateTime;
+import javax.persistence.AttributeOverride;
+import javax.persistence.Column;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "budget")
+public class BudgetHistory extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    private Integer income;
+
+    private Integer outcome;
+
+    private LocalDateTime dateUsed;
+
+    private String title;
+
+    private String details;
+
+//    private List<File> receipts;
+
+    @Embedded
+    @AttributeOverride(name = "id", column = @Column(name = "person_in_charge", nullable = false))
+    private MemberId personInCharge;
+
+    @Embedded
+    @AttributeOverride(name = "id", column = @Column(name = "person_received"))
+    private MemberId personReceived;
+
+    public MemberId getPersonReceived() {
+        return personReceived;
+    }
+
+    public MemberId getPersonInCharge() {
+        return personInCharge;
+    }
+
+    public boolean cannotModifiableBy(MemberId CFO) {
+        return !this.personInCharge.equals(CFO);
+    }
+
+    @Builder
+    public BudgetHistory(Integer income, Integer outcome, LocalDateTime dateUsed,
+            String title, String details, MemberId personInCharge, MemberId personReceived) {
+        this.income = income;
+        this.outcome = outcome;
+        this.dateUsed = dateUsed;
+        this.title = title;
+        this.details = details;
+        this.personInCharge = personInCharge;
+        this.personReceived = personReceived;
+    }
+
+    public BudgetHistory modify(MemberId currentCFO, Integer income, Integer outcome, LocalDateTime dateUsed,
+            String title, String details, MemberId personReceived) {
+
+        if (this.id == null) {
+            throw new NotFoundBudgetHistoryException("cannot modify this entity, because not persisted ever!");
+        }
+
+        if (this.cannotModifiableBy(currentCFO))
+            throw new HistoryCannotModifiableException();
+
+        this.title = title;
+        this.details = details;
+        this.dateUsed = dateUsed;
+        this.income = income;
+        this.outcome = outcome;
+        this.personReceived = personReceived;
+
+        return this;
+    }
+}

--- a/resource-server/src/main/java/com/inhabas/api/domain/budget/dto/BudgetHistoryCreateForm.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/budget/dto/BudgetHistoryCreateForm.java
@@ -1,0 +1,61 @@
+package com.inhabas.api.domain.budget.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.inhabas.api.domain.budget.domain.BudgetHistory;
+import com.inhabas.api.domain.member.domain.valueObject.MemberId;
+import java.time.LocalDateTime;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Past;
+import javax.validation.constraints.PositiveOrZero;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BudgetHistoryCreateForm {
+
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    @Past @NotNull
+    private LocalDateTime dateUsed;
+
+    @NotBlank
+    private String title;
+
+    private String details;
+
+    @NotNull
+    private MemberId personReceived;
+
+    @PositiveOrZero @NotNull
+    private Integer income;
+
+    @PositiveOrZero @NotNull
+    private Integer outcome;
+
+    public BudgetHistoryCreateForm(LocalDateTime dateUsed, String title, String details,
+            @NotNull Integer personReceived, Integer income, Integer outcome) {
+        this.dateUsed = dateUsed;
+        this.title = title;
+        this.details = details;
+        this.personReceived = new MemberId(personReceived);
+        this.income = income;
+        this.outcome = outcome;
+
+        if (this.details.isBlank())
+            this.details = this.title;
+    }
+
+    public BudgetHistory toEntity(MemberId CFO) {
+        return BudgetHistory.builder()
+                .title(this.title)
+                .details(this.details)
+                .income(this.income)
+                .outcome(this.outcome)
+                .dateUsed(this.dateUsed)
+                .personReceived(this.getPersonReceived())
+                .personInCharge(CFO)
+                .build();
+    }
+}

--- a/resource-server/src/main/java/com/inhabas/api/domain/budget/dto/BudgetHistoryDetailDto.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/budget/dto/BudgetHistoryDetailDto.java
@@ -1,8 +1,11 @@
 package com.inhabas.api.domain.budget.dto;
 
-import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 
+import java.time.LocalDateTime;
+
+@Getter
 @AllArgsConstructor
 public class BudgetHistoryDetailDto {
 

--- a/resource-server/src/main/java/com/inhabas/api/domain/budget/dto/BudgetHistoryDetailDto.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/budget/dto/BudgetHistoryDetailDto.java
@@ -1,0 +1,30 @@
+package com.inhabas.api.domain.budget.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public class BudgetHistoryDetailDto {
+
+    private LocalDateTime dateUsed;
+
+    private LocalDateTime dateCreated;
+
+    private LocalDateTime dateModified;
+
+    private String title;
+
+    private Integer income;
+
+    private Integer outcome;
+
+    private String details;
+
+    private Integer receivedMemberId;
+
+    private String receivedMemberName;
+
+    private Integer memberIdInCharge;
+
+    private String memberNameInCharge;
+}

--- a/resource-server/src/main/java/com/inhabas/api/domain/budget/dto/BudgetHistoryModifyForm.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/budget/dto/BudgetHistoryModifyForm.java
@@ -1,0 +1,23 @@
+package com.inhabas.api.domain.budget.dto;
+
+import java.time.LocalDateTime;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BudgetHistoryModifyForm extends BudgetHistoryCreateForm {
+
+    @NotNull @Positive
+    private Integer id;
+
+    public BudgetHistoryModifyForm(LocalDateTime dateUsed, String title,
+            String details, Integer personReceived, Integer income, Integer outcome,
+            Integer historyId) {
+        super(dateUsed, title, details, personReceived, income, outcome);
+        this.id = historyId;
+    }
+}

--- a/resource-server/src/main/java/com/inhabas/api/domain/budget/repository/BudgetHistoryRepository.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/budget/repository/BudgetHistoryRepository.java
@@ -1,0 +1,8 @@
+package com.inhabas.api.domain.budget.repository;
+
+import com.inhabas.api.domain.budget.domain.BudgetHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BudgetHistoryRepository extends JpaRepository<BudgetHistory, Integer> {
+
+}

--- a/resource-server/src/main/java/com/inhabas/api/domain/budget/repository/BudgetHistoryRepository.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/budget/repository/BudgetHistoryRepository.java
@@ -3,6 +3,6 @@ package com.inhabas.api.domain.budget.repository;
 import com.inhabas.api.domain.budget.domain.BudgetHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface BudgetHistoryRepository extends JpaRepository<BudgetHistory, Integer> {
+public interface BudgetHistoryRepository extends JpaRepository<BudgetHistory, Integer>, BudgetHistoryRepositoryCustom {
 
 }

--- a/resource-server/src/main/java/com/inhabas/api/domain/budget/repository/BudgetHistoryRepositoryCustom.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/budget/repository/BudgetHistoryRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.inhabas.api.domain.budget.repository;
+
+import com.inhabas.api.domain.budget.dto.BudgetHistoryDetailDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface BudgetHistoryRepositoryCustom {
+
+    Page<BudgetHistoryDetailDto> findAllByPageable(Pageable pageable);
+
+}

--- a/resource-server/src/main/java/com/inhabas/api/domain/budget/repository/BudgetHistoryRepositoryCustom.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/budget/repository/BudgetHistoryRepositoryCustom.java
@@ -4,6 +4,7 @@ import com.inhabas.api.domain.budget.dto.BudgetHistoryDetailDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface BudgetHistoryRepositoryCustom {
@@ -11,4 +12,6 @@ public interface BudgetHistoryRepositoryCustom {
     Page<BudgetHistoryDetailDto> search(Integer year, Pageable pageable);
 
     Optional<BudgetHistoryDetailDto> findDtoById(Integer id);
+
+    List<Integer> findAllYear();
 }

--- a/resource-server/src/main/java/com/inhabas/api/domain/budget/repository/BudgetHistoryRepositoryCustom.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/budget/repository/BudgetHistoryRepositoryCustom.java
@@ -4,8 +4,11 @@ import com.inhabas.api.domain.budget.dto.BudgetHistoryDetailDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.Optional;
+
 public interface BudgetHistoryRepositoryCustom {
 
     Page<BudgetHistoryDetailDto> findAllByPageable(Pageable pageable);
 
+    Optional<BudgetHistoryDetailDto> findDtoById(Integer id);
 }

--- a/resource-server/src/main/java/com/inhabas/api/domain/budget/repository/BudgetHistoryRepositoryCustom.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/budget/repository/BudgetHistoryRepositoryCustom.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 
 public interface BudgetHistoryRepositoryCustom {
 
-    Page<BudgetHistoryDetailDto> findAllByPageable(Pageable pageable);
+    Page<BudgetHistoryDetailDto> search(Integer year, Pageable pageable);
 
     Optional<BudgetHistoryDetailDto> findDtoById(Integer id);
 }

--- a/resource-server/src/main/java/com/inhabas/api/domain/budget/repository/BudgetHistoryRepositoryImpl.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/budget/repository/BudgetHistoryRepositoryImpl.java
@@ -1,0 +1,55 @@
+package com.inhabas.api.domain.budget.repository;
+
+import static com.inhabas.api.domain.budget.domain.QBudgetHistory.budgetHistory;
+
+import com.inhabas.api.domain.budget.dto.BudgetHistoryDetailDto;
+import com.inhabas.api.domain.member.domain.entity.QMember;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+@RequiredArgsConstructor
+public class BudgetHistoryRepositoryImpl implements BudgetHistoryRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<BudgetHistoryDetailDto> findAllByPageable(Pageable pageable) {
+
+        QMember memberInCharge = new QMember("inCharge");
+        QMember memberReceived = new QMember("received");
+
+        List<BudgetHistoryDetailDto> result = queryFactory.select(
+                        Projections.constructor(BudgetHistoryDetailDto.class,
+                                budgetHistory.dateUsed,
+                                budgetHistory.created,
+                                budgetHistory.updated,
+                                budgetHistory.title,
+                                budgetHistory.income,
+                                budgetHistory.outcome,
+                                budgetHistory.details,
+                                budgetHistory.personReceived.id,
+                                memberReceived.name.value,
+                                budgetHistory.personInCharge.id,
+                                memberInCharge.name.value
+                                ))
+                .from(budgetHistory)
+                .innerJoin(memberInCharge).on(memberInCharge.id.id.eq(budgetHistory.personInCharge.id))
+                .innerJoin(memberReceived).on(memberReceived.id.id.eq(budgetHistory.personReceived.id))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy()
+                .fetch();
+
+        return new PageImpl<>(result, pageable, getCount());
+    }
+
+    // need to cache such as EHCACHE later.
+    private Integer getCount() {
+        return queryFactory.selectFrom(budgetHistory).fetch().size();
+    }
+}

--- a/resource-server/src/main/java/com/inhabas/api/domain/budget/repository/BudgetHistoryRepositoryImpl.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/budget/repository/BudgetHistoryRepositoryImpl.java
@@ -1,29 +1,63 @@
 package com.inhabas.api.domain.budget.repository;
 
-import static com.inhabas.api.domain.budget.domain.QBudgetHistory.budgetHistory;
-
 import com.inhabas.api.domain.budget.dto.BudgetHistoryDetailDto;
 import com.inhabas.api.domain.member.domain.entity.QMember;
 import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.util.List;
-import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
-@RequiredArgsConstructor
+import java.util.List;
+import java.util.Optional;
+
+import static com.inhabas.api.domain.budget.domain.QBudgetHistory.budgetHistory;
+
 public class BudgetHistoryRepositoryImpl implements BudgetHistoryRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
+    private final QMember memberInCharge = new QMember("inCharge");
+    private final QMember memberReceived = new QMember("received");
+
+
+    public BudgetHistoryRepositoryImpl(JPAQueryFactory queryFactory) {
+        this.queryFactory = queryFactory;
+    }
+
+
+    @Override
+    public Optional<BudgetHistoryDetailDto> findDtoById(Integer id) {
+
+        return Optional.ofNullable(
+                getDtoJPAQuery()
+                .where(budgetHistory.id.eq(id))
+                .fetchOne());
+    }
+
 
     @Override
     public Page<BudgetHistoryDetailDto> findAllByPageable(Pageable pageable) {
 
-        QMember memberInCharge = new QMember("inCharge");
-        QMember memberReceived = new QMember("received");
+        List<BudgetHistoryDetailDto> result = getDtoJPAQuery()
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy()
+                .fetch();
 
-        List<BudgetHistoryDetailDto> result = queryFactory.select(
+        return new PageImpl<>(result, pageable, getCount());
+    }
+
+
+    // need to cache such as EHCACHE later.
+    private Integer getCount() {
+        return queryFactory.selectFrom(budgetHistory).fetch().size();
+    }
+
+
+    private JPAQuery<BudgetHistoryDetailDto> getDtoJPAQuery() {
+
+        return queryFactory.select(
                         Projections.constructor(BudgetHistoryDetailDto.class,
                                 budgetHistory.dateUsed,
                                 budgetHistory.created,
@@ -36,20 +70,9 @@ public class BudgetHistoryRepositoryImpl implements BudgetHistoryRepositoryCusto
                                 memberReceived.name.value,
                                 budgetHistory.personInCharge.id,
                                 memberInCharge.name.value
-                                ))
+                        ))
                 .from(budgetHistory)
                 .innerJoin(memberInCharge).on(memberInCharge.id.id.eq(budgetHistory.personInCharge.id))
-                .innerJoin(memberReceived).on(memberReceived.id.id.eq(budgetHistory.personReceived.id))
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .orderBy()
-                .fetch();
-
-        return new PageImpl<>(result, pageable, getCount());
-    }
-
-    // need to cache such as EHCACHE later.
-    private Integer getCount() {
-        return queryFactory.selectFrom(budgetHistory).fetch().size();
+                .innerJoin(memberReceived).on(memberReceived.id.id.eq(budgetHistory.personReceived.id));
     }
 }

--- a/resource-server/src/main/java/com/inhabas/api/domain/budget/repository/BudgetHistoryRepositoryImpl.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/budget/repository/BudgetHistoryRepositoryImpl.java
@@ -51,6 +51,18 @@ public class BudgetHistoryRepositoryImpl implements BudgetHistoryRepositoryCusto
         return new PageImpl<>(result, pageable, getCount(year));
     }
 
+
+    @Override
+    public List<Integer> findAllYear() {
+        return queryFactory
+                .select(budgetHistory.dateUsed.year())
+                .from(budgetHistory)
+                .distinct()
+                .orderBy(budgetHistory.dateUsed.desc())
+                .fetch();
+    }
+
+
     private BooleanExpression createdIn(Integer year) {
         return year == null ?
                 Expressions.asBoolean(true).isTrue()

--- a/resource-server/src/main/java/com/inhabas/api/domain/budget/usecase/BudgetHistoryService.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/budget/usecase/BudgetHistoryService.java
@@ -15,7 +15,7 @@ public interface BudgetHistoryService {
 
     void deleteHistory(Integer historyId, MemberId CFO);
 
-    Page<BudgetHistoryDetailDto> getHistoryList(Pageable pageable);
+    Page<BudgetHistoryDetailDto> searchHistoryList(Integer year, Pageable pageable);
 
     BudgetHistoryDetailDto getHistory(Integer id);
 }

--- a/resource-server/src/main/java/com/inhabas/api/domain/budget/usecase/BudgetHistoryService.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/budget/usecase/BudgetHistoryService.java
@@ -1,8 +1,11 @@
 package com.inhabas.api.domain.budget.usecase;
 
 import com.inhabas.api.domain.budget.dto.BudgetHistoryCreateForm;
+import com.inhabas.api.domain.budget.dto.BudgetHistoryDetailDto;
 import com.inhabas.api.domain.budget.dto.BudgetHistoryModifyForm;
 import com.inhabas.api.domain.member.domain.valueObject.MemberId;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface BudgetHistoryService {
 
@@ -11,4 +14,6 @@ public interface BudgetHistoryService {
     void modifyHistory(BudgetHistoryModifyForm historyId, MemberId CFO);
 
     void deleteHistory(Integer historyId, MemberId CFO);
+
+    Page<BudgetHistoryDetailDto> getHistoryList(Pageable pageable);
 }

--- a/resource-server/src/main/java/com/inhabas/api/domain/budget/usecase/BudgetHistoryService.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/budget/usecase/BudgetHistoryService.java
@@ -1,0 +1,14 @@
+package com.inhabas.api.domain.budget.usecase;
+
+import com.inhabas.api.domain.budget.dto.BudgetHistoryCreateForm;
+import com.inhabas.api.domain.budget.dto.BudgetHistoryModifyForm;
+import com.inhabas.api.domain.member.domain.valueObject.MemberId;
+
+public interface BudgetHistoryService {
+
+    void createNewHistory(BudgetHistoryCreateForm form, MemberId CFO);
+
+    void modifyHistory(BudgetHistoryModifyForm historyId, MemberId CFO);
+
+    void deleteHistory(Integer historyId, MemberId CFO);
+}

--- a/resource-server/src/main/java/com/inhabas/api/domain/budget/usecase/BudgetHistoryService.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/budget/usecase/BudgetHistoryService.java
@@ -16,4 +16,6 @@ public interface BudgetHistoryService {
     void deleteHistory(Integer historyId, MemberId CFO);
 
     Page<BudgetHistoryDetailDto> getHistoryList(Pageable pageable);
+
+    BudgetHistoryDetailDto getHistory(Integer id);
 }

--- a/resource-server/src/main/java/com/inhabas/api/domain/budget/usecase/BudgetHistoryService.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/budget/usecase/BudgetHistoryService.java
@@ -7,6 +7,8 @@ import com.inhabas.api.domain.member.domain.valueObject.MemberId;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface BudgetHistoryService {
 
     void createNewHistory(BudgetHistoryCreateForm form, MemberId CFO);
@@ -18,4 +20,6 @@ public interface BudgetHistoryService {
     Page<BudgetHistoryDetailDto> searchHistoryList(Integer year, Pageable pageable);
 
     BudgetHistoryDetailDto getHistory(Integer id);
+
+    List<Integer> getAllYearOfHistory();
 }

--- a/resource-server/src/main/java/com/inhabas/api/domain/budget/usecase/BudgetHistoryServiceImpl.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/budget/usecase/BudgetHistoryServiceImpl.java
@@ -14,6 +14,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 
 @Service
 @Transactional(readOnly = true)
@@ -72,5 +74,8 @@ public class BudgetHistoryServiceImpl implements BudgetHistoryService {
                 .orElseThrow(NotFoundBudgetHistoryException::new);
     }
 
-
+    @Override
+    public List<Integer> getAllYearOfHistory() {
+        return repository.findAllYear();
+    }
 }

--- a/resource-server/src/main/java/com/inhabas/api/domain/budget/usecase/BudgetHistoryServiceImpl.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/budget/usecase/BudgetHistoryServiceImpl.java
@@ -8,20 +8,22 @@ import com.inhabas.api.domain.budget.dto.BudgetHistoryDetailDto;
 import com.inhabas.api.domain.budget.dto.BudgetHistoryModifyForm;
 import com.inhabas.api.domain.budget.repository.BudgetHistoryRepository;
 import com.inhabas.api.domain.member.domain.valueObject.MemberId;
-import javax.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 
 @Service
-@Transactional
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class BudgetHistoryServiceImpl implements BudgetHistoryService {
 
     private final BudgetHistoryRepository repository;
 
     @Override
+    @Transactional
     public void createNewHistory(BudgetHistoryCreateForm form, MemberId CFO) {
 
         BudgetHistory newHistory = form.toEntity(CFO);
@@ -30,6 +32,7 @@ public class BudgetHistoryServiceImpl implements BudgetHistoryService {
     }
 
     @Override
+    @Transactional
     public void modifyHistory(BudgetHistoryModifyForm form, MemberId CFO) {
 
         BudgetHistory budgetHistory = repository.findById(form.getId())
@@ -44,6 +47,7 @@ public class BudgetHistoryServiceImpl implements BudgetHistoryService {
 
 
     @Override
+    @Transactional
     public void deleteHistory(Integer historyId, MemberId CFO) {
 
         BudgetHistory budgetHistory = repository.findById(historyId)
@@ -60,6 +64,12 @@ public class BudgetHistoryServiceImpl implements BudgetHistoryService {
     public Page<BudgetHistoryDetailDto> getHistoryList(Pageable pageable) {
 
         return repository.findAllByPageable(pageable);
+    }
+
+    @Override
+    public BudgetHistoryDetailDto getHistory(Integer id) {
+        return repository.findDtoById(id)
+                .orElseThrow(NotFoundBudgetHistoryException::new);
     }
 
 

--- a/resource-server/src/main/java/com/inhabas/api/domain/budget/usecase/BudgetHistoryServiceImpl.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/budget/usecase/BudgetHistoryServiceImpl.java
@@ -61,9 +61,9 @@ public class BudgetHistoryServiceImpl implements BudgetHistoryService {
     }
 
     @Override
-    public Page<BudgetHistoryDetailDto> getHistoryList(Pageable pageable) {
+    public Page<BudgetHistoryDetailDto> searchHistoryList(Integer year, Pageable pageable) {
 
-        return repository.findAllByPageable(pageable);
+        return repository.search(year, pageable);
     }
 
     @Override

--- a/resource-server/src/main/java/com/inhabas/api/domain/budget/usecase/BudgetHistoryServiceImpl.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/budget/usecase/BudgetHistoryServiceImpl.java
@@ -4,11 +4,14 @@ import com.inhabas.api.domain.budget.HistoryCannotModifiableException;
 import com.inhabas.api.domain.budget.NotFoundBudgetHistoryException;
 import com.inhabas.api.domain.budget.domain.BudgetHistory;
 import com.inhabas.api.domain.budget.dto.BudgetHistoryCreateForm;
+import com.inhabas.api.domain.budget.dto.BudgetHistoryDetailDto;
 import com.inhabas.api.domain.budget.dto.BudgetHistoryModifyForm;
 import com.inhabas.api.domain.budget.repository.BudgetHistoryRepository;
 import com.inhabas.api.domain.member.domain.valueObject.MemberId;
 import javax.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -51,6 +54,12 @@ public class BudgetHistoryServiceImpl implements BudgetHistoryService {
         }
 
         repository.deleteById(historyId);
+    }
+
+    @Override
+    public Page<BudgetHistoryDetailDto> getHistoryList(Pageable pageable) {
+
+        return repository.findAllByPageable(pageable);
     }
 
 

--- a/resource-server/src/main/java/com/inhabas/api/domain/budget/usecase/BudgetHistoryServiceImpl.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/budget/usecase/BudgetHistoryServiceImpl.java
@@ -1,0 +1,57 @@
+package com.inhabas.api.domain.budget.usecase;
+
+import com.inhabas.api.domain.budget.HistoryCannotModifiableException;
+import com.inhabas.api.domain.budget.NotFoundBudgetHistoryException;
+import com.inhabas.api.domain.budget.domain.BudgetHistory;
+import com.inhabas.api.domain.budget.dto.BudgetHistoryCreateForm;
+import com.inhabas.api.domain.budget.dto.BudgetHistoryModifyForm;
+import com.inhabas.api.domain.budget.repository.BudgetHistoryRepository;
+import com.inhabas.api.domain.member.domain.valueObject.MemberId;
+import javax.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class BudgetHistoryServiceImpl implements BudgetHistoryService {
+
+    private final BudgetHistoryRepository repository;
+
+    @Override
+    public void createNewHistory(BudgetHistoryCreateForm form, MemberId CFO) {
+
+        BudgetHistory newHistory = form.toEntity(CFO);
+
+        repository.save(newHistory);
+    }
+
+    @Override
+    public void modifyHistory(BudgetHistoryModifyForm form, MemberId CFO) {
+
+        BudgetHistory budgetHistory = repository.findById(form.getId())
+                .orElseThrow(NotFoundBudgetHistoryException::new);
+
+        budgetHistory.modify(
+                CFO, form.getIncome(), form.getOutcome(), form.getDateUsed(),
+                form.getTitle(), form.getDetails(), form.getPersonReceived());
+
+        repository.save(budgetHistory);
+    }
+
+
+    @Override
+    public void deleteHistory(Integer historyId, MemberId CFO) {
+
+        BudgetHistory budgetHistory = repository.findById(historyId)
+                .orElseThrow(NotFoundBudgetHistoryException::new);
+
+        if (budgetHistory.cannotModifiableBy(CFO)) {
+            throw new HistoryCannotModifiableException();
+        }
+
+        repository.deleteById(historyId);
+    }
+
+
+}

--- a/resource-server/src/main/java/com/inhabas/api/domain/comment/dto/CommentSaveDto.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/comment/dto/CommentSaveDto.java
@@ -26,8 +26,8 @@ public class CommentSaveDto {
     @NotNull @Positive
     private Integer boardId;
 
-    public CommentSaveDto(MemberId writerId, String contents, Integer boardId) {
-        this.writerId = writerId;
+    public CommentSaveDto(Integer writerId, String contents, Integer boardId) {
+        this.writerId = new MemberId(writerId);
         this.contents = contents;
         this.boardId = boardId;
     }

--- a/resource-server/src/main/java/com/inhabas/api/web/BudgetHistoryController.java
+++ b/resource-server/src/main/java/com/inhabas/api/web/BudgetHistoryController.java
@@ -6,21 +6,15 @@ import com.inhabas.api.domain.budget.dto.BudgetHistoryModifyForm;
 import com.inhabas.api.domain.budget.usecase.BudgetHistoryService;
 import com.inhabas.api.domain.member.domain.valueObject.MemberId;
 import com.inhabas.api.web.argumentResolver.Authenticated;
-import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
 
 @RestController
 @RequestMapping("/budget/history")
@@ -64,6 +58,14 @@ public class BudgetHistoryController {
         Page<BudgetHistoryDetailDto> historyList = budgetHistoryService.getHistoryList(pageable);
 
         return ResponseEntity.ok(historyList);
+    }
+
+    @GetMapping
+    public ResponseEntity<BudgetHistoryDetailDto> getBudgetHistory(@RequestParam("id") Integer historyId) {
+
+        BudgetHistoryDetailDto history = budgetHistoryService.getHistory(historyId);
+
+        return ResponseEntity.ok(history);
     }
 
 }

--- a/resource-server/src/main/java/com/inhabas/api/web/BudgetHistoryController.java
+++ b/resource-server/src/main/java/com/inhabas/api/web/BudgetHistoryController.java
@@ -6,6 +6,10 @@ import com.inhabas.api.domain.budget.dto.BudgetHistoryModifyForm;
 import com.inhabas.api.domain.budget.usecase.BudgetHistoryService;
 import com.inhabas.api.domain.member.domain.valueObject.MemberId;
 import com.inhabas.api.web.argumentResolver.Authenticated;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -19,13 +23,20 @@ import javax.validation.Valid;
 import java.util.List;
 
 @RestController
+@Tag(name = "회계내역")
 @RequestMapping("/budget/history")
 @RequiredArgsConstructor
 public class BudgetHistoryController {
 
     private final BudgetHistoryService budgetHistoryService;
 
+    @Operation(summary = "새로운 회계 내역을 추가한다.")
     @PostMapping
+    @ApiResponses({
+            @ApiResponse(responseCode = "204"),
+            @ApiResponse(responseCode = "400", description = "잘못된 입력"),
+            @ApiResponse(responseCode = "401", description = "총무가 아니면 접근 불가")
+    })
     public ResponseEntity<?> createNewHistory(
             @Authenticated MemberId memberId, @Valid @RequestBody BudgetHistoryCreateForm form) {
 
@@ -34,7 +45,13 @@ public class BudgetHistoryController {
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(summary = "회계 내역을 수정한다.")
     @PutMapping
+    @ApiResponses({
+            @ApiResponse(responseCode = "204"),
+            @ApiResponse(responseCode = "400", description = "잘못된 입력, 또는 id가 존재하지 않는 경우"),
+            @ApiResponse(responseCode = "401", description = "총무가 아니면 접근 불가, 다른 총무가 작성한 것 수정 불가")
+    })
     public ResponseEntity<?> modifyHistory(
             @Authenticated MemberId memberId, @Valid @RequestBody BudgetHistoryModifyForm form) {
 
@@ -43,7 +60,13 @@ public class BudgetHistoryController {
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(summary = "회계 내역을 삭제한다.")
     @DeleteMapping("/{historyId}")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204"),
+            @ApiResponse(responseCode = "400", description = "잘못된 입력, 또는 id가 존재하지 않는 경우"),
+            @ApiResponse(responseCode = "401", description = "총무가 아니면 접근 불가, 다른 총무가 작성한 것 삭제 불가")
+    })
     public ResponseEntity<?> deleteHistory(
             @Authenticated MemberId memberId,
             @PathVariable Integer historyId) {
@@ -53,7 +76,9 @@ public class BudgetHistoryController {
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(summary = "회계 내역을 검색한다.")
     @GetMapping("/search")
+    @ApiResponse(responseCode = "200", description = "검색 결과를 pagination 적용해서 반환, year 값 안주면 전체기간으로 적용됨.")
     public ResponseEntity<Page<BudgetHistoryDetailDto>> searchBudgetHistory(
             @Nullable @RequestParam Integer year,
             @PageableDefault(size = 15, sort = "dateUsed", direction = Direction.DESC) Pageable pageable) {
@@ -63,7 +88,12 @@ public class BudgetHistoryController {
         return ResponseEntity.ok(historyList);
     }
 
+    @Operation(summary = "단일 회계 내역을 조회한다.")
     @GetMapping("/{historyId}")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "400", description = "잘못된 입력, 또는 id가 존재하지 않는 경우"),
+    })
     public ResponseEntity<BudgetHistoryDetailDto> getBudgetHistory(@PathVariable Integer historyId) {
 
         BudgetHistoryDetailDto history = budgetHistoryService.getHistory(historyId);
@@ -71,7 +101,9 @@ public class BudgetHistoryController {
         return ResponseEntity.ok(history);
     }
 
+    @Operation(summary = "회계 내역이 작성된 기간동안의 연도 목록을 가져온다.")
     @GetMapping("/years")
+    @ApiResponse(responseCode = "200")
     public ResponseEntity<List<Integer>> getAllYearsOfHistory() {
 
         return ResponseEntity.ok(budgetHistoryService.getAllYearOfHistory());

--- a/resource-server/src/main/java/com/inhabas/api/web/BudgetHistoryController.java
+++ b/resource-server/src/main/java/com/inhabas/api/web/BudgetHistoryController.java
@@ -16,6 +16,7 @@ import org.springframework.lang.Nullable;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.util.List;
 
 @RestController
 @RequestMapping("/budget/history")
@@ -70,4 +71,9 @@ public class BudgetHistoryController {
         return ResponseEntity.ok(history);
     }
 
+    @GetMapping("/years")
+    public ResponseEntity<List<Integer>> getAllYearsOfHistory() {
+
+        return ResponseEntity.ok(budgetHistoryService.getAllYearOfHistory());
+    }
 }

--- a/resource-server/src/main/java/com/inhabas/api/web/BudgetHistoryController.java
+++ b/resource-server/src/main/java/com/inhabas/api/web/BudgetHistoryController.java
@@ -1,14 +1,20 @@
 package com.inhabas.api.web;
 
 import com.inhabas.api.domain.budget.dto.BudgetHistoryCreateForm;
+import com.inhabas.api.domain.budget.dto.BudgetHistoryDetailDto;
 import com.inhabas.api.domain.budget.dto.BudgetHistoryModifyForm;
 import com.inhabas.api.domain.budget.usecase.BudgetHistoryService;
 import com.inhabas.api.domain.member.domain.valueObject.MemberId;
 import com.inhabas.api.web.argumentResolver.Authenticated;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -50,4 +56,14 @@ public class BudgetHistoryController {
 
         return ResponseEntity.noContent().build();
     }
+
+    @GetMapping("/get")
+    public ResponseEntity<Page<BudgetHistoryDetailDto>> getListBudgetHistory(
+            @PageableDefault(size = 15, sort = "dateUsed", direction = Direction.DESC) Pageable pageable) {
+
+        Page<BudgetHistoryDetailDto> historyList = budgetHistoryService.getHistoryList(pageable);
+
+        return ResponseEntity.ok(historyList);
+    }
+
 }

--- a/resource-server/src/main/java/com/inhabas/api/web/BudgetHistoryController.java
+++ b/resource-server/src/main/java/com/inhabas/api/web/BudgetHistoryController.java
@@ -1,0 +1,53 @@
+package com.inhabas.api.web;
+
+import com.inhabas.api.domain.budget.dto.BudgetHistoryCreateForm;
+import com.inhabas.api.domain.budget.dto.BudgetHistoryModifyForm;
+import com.inhabas.api.domain.budget.usecase.BudgetHistoryService;
+import com.inhabas.api.domain.member.domain.valueObject.MemberId;
+import com.inhabas.api.web.argumentResolver.Authenticated;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/budget/history")
+@RequiredArgsConstructor
+public class BudgetHistoryController {
+
+    private final BudgetHistoryService budgetHistoryService;
+
+    @PostMapping("/create")
+    public ResponseEntity<?> createNewHistory(
+            @Authenticated MemberId memberId, @Valid @RequestBody BudgetHistoryCreateForm form) {
+
+        budgetHistoryService.createNewHistory(form, memberId);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @PutMapping("/update")
+    public ResponseEntity<?> modifyHistory(
+            @Authenticated MemberId memberId, @Valid @RequestBody BudgetHistoryModifyForm form) {
+
+        budgetHistoryService.modifyHistory(form, memberId);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/delete")
+    public ResponseEntity<?> deleteHistory(
+            @Authenticated MemberId memberId,
+            @RequestParam(name = "id") Integer historyId) {
+
+        budgetHistoryService.deleteHistory(historyId, memberId);
+
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/resource-server/src/main/java/com/inhabas/api/web/BudgetHistoryController.java
+++ b/resource-server/src/main/java/com/inhabas/api/web/BudgetHistoryController.java
@@ -12,6 +12,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.lang.Nullable;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -51,11 +52,12 @@ public class BudgetHistoryController {
         return ResponseEntity.noContent().build();
     }
 
-    @GetMapping("/get")
-    public ResponseEntity<Page<BudgetHistoryDetailDto>> getListBudgetHistory(
+    @GetMapping("/search")
+    public ResponseEntity<Page<BudgetHistoryDetailDto>> searchBudgetHistory(
+            @Nullable @RequestParam Integer year,
             @PageableDefault(size = 15, sort = "dateUsed", direction = Direction.DESC) Pageable pageable) {
 
-        Page<BudgetHistoryDetailDto> historyList = budgetHistoryService.getHistoryList(pageable);
+        Page<BudgetHistoryDetailDto> historyList = budgetHistoryService.searchHistoryList(year, pageable);
 
         return ResponseEntity.ok(historyList);
     }

--- a/resource-server/src/main/java/com/inhabas/api/web/BudgetHistoryController.java
+++ b/resource-server/src/main/java/com/inhabas/api/web/BudgetHistoryController.java
@@ -25,7 +25,7 @@ public class BudgetHistoryController {
 
     private final BudgetHistoryService budgetHistoryService;
 
-    @PostMapping("/create")
+    @PostMapping
     public ResponseEntity<?> createNewHistory(
             @Authenticated MemberId memberId, @Valid @RequestBody BudgetHistoryCreateForm form) {
 
@@ -34,7 +34,7 @@ public class BudgetHistoryController {
         return ResponseEntity.noContent().build();
     }
 
-    @PutMapping("/update")
+    @PutMapping
     public ResponseEntity<?> modifyHistory(
             @Authenticated MemberId memberId, @Valid @RequestBody BudgetHistoryModifyForm form) {
 
@@ -43,10 +43,10 @@ public class BudgetHistoryController {
         return ResponseEntity.noContent().build();
     }
 
-    @DeleteMapping("/delete")
+    @DeleteMapping("/{historyId}")
     public ResponseEntity<?> deleteHistory(
             @Authenticated MemberId memberId,
-            @RequestParam(name = "id") Integer historyId) {
+            @PathVariable Integer historyId) {
 
         budgetHistoryService.deleteHistory(historyId, memberId);
 
@@ -63,8 +63,8 @@ public class BudgetHistoryController {
         return ResponseEntity.ok(historyList);
     }
 
-    @GetMapping
-    public ResponseEntity<BudgetHistoryDetailDto> getBudgetHistory(@RequestParam("id") Integer historyId) {
+    @GetMapping("/{historyId}")
+    public ResponseEntity<BudgetHistoryDetailDto> getBudgetHistory(@PathVariable Integer historyId) {
 
         BudgetHistoryDetailDto history = budgetHistoryService.getHistory(historyId);
 

--- a/resource-server/src/main/resources/bootstrap.yml
+++ b/resource-server/src/main/resources/bootstrap.yml
@@ -14,7 +14,7 @@ management:
 spring:
   config:
     activate:
-      on-profile: default_mvc_test, no_security_mvc_test
+      on-profile: default_mvc_test, no_security_mvc_test, test
   cloud:
     discovery:
       enabled: false

--- a/resource-server/src/test/java/com/inhabas/api/domain/budget/repository/BudgetHistoryRepositoryTest.java
+++ b/resource-server/src/test/java/com/inhabas/api/domain/budget/repository/BudgetHistoryRepositoryTest.java
@@ -84,7 +84,7 @@ public class BudgetHistoryRepositoryTest {
                             .details("과자" + i)
                             .income(0)
                             .outcome(500000)
-                            .dateUsed(LocalDateTime.of(2000, 1, 1, 1, 1, 1))
+                            .dateUsed(LocalDateTime.of(2000, 1, i, 1, 1, 1))
                             .personReceived(received)
                             .personInCharge(inCharge)
                             .build());
@@ -92,7 +92,7 @@ public class BudgetHistoryRepositoryTest {
         budgetHistoryRepository.saveAll(histories);
 
         //when
-        Page<BudgetHistoryDetailDto> page = budgetHistoryRepository.findAllByPageable(
+        Page<BudgetHistoryDetailDto> page = budgetHistoryRepository.search(null,
                 PageRequest.of(1, 20, Direction.DESC, "dateUsed"));
 
 
@@ -100,6 +100,36 @@ public class BudgetHistoryRepositoryTest {
         assertThat(page.getTotalElements()).isEqualTo(30);
         assertThat(page.getNumberOfElements()).isEqualTo(10);
         assertThat(page.getTotalPages()).isEqualTo(2);
-        assertThat(page.getContent().get(0)).extracting("title").isEqualTo("간식비21");
+        assertThat(page.getContent().get(0)).extracting("title").isEqualTo("간식비10");
+    }
+
+    @DisplayName("2021년도 예산 내역만 가져온다.")
+    @Test
+    public void searchBudgetHistoryByYearTest() {
+
+        //given
+        List<BudgetHistory> histories = new ArrayList<>();
+        for (int i = 1; i < 21; i++) {
+            histories.add(
+                    BudgetHistory.builder()
+                            .title("간식비2000")
+                            .details("과자2000")
+                            .income(0)
+                            .outcome(500000)
+                            .dateUsed(LocalDateTime.of(2000 + (i / 15), 1, 1, 1, 1, 1))
+                            .personReceived(received)
+                            .personInCharge(inCharge)
+                            .build());
+        }
+        budgetHistoryRepository.saveAll(histories);
+
+        //when
+        Page<BudgetHistoryDetailDto> page = budgetHistoryRepository.search(2001,
+                PageRequest.of(0, 15, Direction.DESC, "dateUsed"));
+
+        //then
+        assertThat(page.getTotalElements()).isEqualTo(6);
+        assertThat(page.getNumberOfElements()).isEqualTo(6);
+        assertThat(page.getTotalPages()).isEqualTo(1);
     }
 }

--- a/resource-server/src/test/java/com/inhabas/api/domain/budget/repository/BudgetHistoryRepositoryTest.java
+++ b/resource-server/src/test/java/com/inhabas/api/domain/budget/repository/BudgetHistoryRepositoryTest.java
@@ -132,4 +132,31 @@ public class BudgetHistoryRepositoryTest {
         assertThat(page.getNumberOfElements()).isEqualTo(6);
         assertThat(page.getTotalPages()).isEqualTo(1);
     }
+
+    @DisplayName("회계내역이 있는 년도를 모두 가져온다.")
+    @Test
+    public void getAllYearOfHistory() {
+        //given
+        List<BudgetHistory> histories = new ArrayList<>();
+        for (int i = 1; i < 21; i++) {
+            histories.add(
+                    BudgetHistory.builder()
+                            .title("간식비2000")
+                            .details("과자2000")
+                            .income(0)
+                            .outcome(500000)
+                            .dateUsed(LocalDateTime.of(2000 + (i / 3), 1, 1, 1, 1, 1))
+                            .personReceived(received)
+                            .personInCharge(inCharge)
+                            .build());
+        }
+        budgetHistoryRepository.saveAll(histories);
+
+        //when
+        List<Integer> allYear = budgetHistoryRepository.findAllYear();
+
+        //then
+        assertThat(allYear).containsExactly(2006, 2005, 2004, 2003, 2002, 2001, 2000);
+        assertThat(allYear).hasSize(7);
+    }
 }

--- a/resource-server/src/test/java/com/inhabas/api/domain/budget/repository/BudgetHistoryRepositoryTest.java
+++ b/resource-server/src/test/java/com/inhabas/api/domain/budget/repository/BudgetHistoryRepositoryTest.java
@@ -1,0 +1,74 @@
+package com.inhabas.api.domain.budget.repository;
+
+import static com.inhabas.api.domain.member.domain.MemberTest.MEMBER1;
+import static com.inhabas.api.domain.member.domain.MemberTest.MEMBER2;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.inhabas.api.domain.budget.domain.BudgetHistory;
+import com.inhabas.api.domain.budget.dto.BudgetHistoryDetailDto;
+import com.inhabas.api.domain.member.domain.entity.Member;
+import com.inhabas.api.domain.member.domain.valueObject.MemberId;
+import com.inhabas.testAnnotataion.DefaultDataJpaTest;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort.Direction;
+
+@DefaultDataJpaTest
+public class BudgetHistoryRepositoryTest {
+
+    @Autowired
+    private TestEntityManager em;
+    @Autowired
+    private BudgetHistoryRepository budgetHistoryRepository;
+
+    private MemberId received, inCharge;
+
+    @BeforeEach
+    public void setUp() {
+        Member member1 = MEMBER1();
+        Member member2 = MEMBER2();
+        em.persist(member1);
+        em.persist(member2);
+        received = member1.getId();
+        inCharge = member2.getId();
+    }
+
+    @DisplayName("예산 내역 페이지 객체를 가져온다.")
+    @Test
+    public void fetchBudgetHistoryPageTest() {
+        //given
+        List<BudgetHistory> histories = new ArrayList<>();
+        for (int i = 1; i < 31; i++) {
+            histories.add(
+                BudgetHistory.builder()
+                        .title("간식비"+i)
+                        .details("과자"+i)
+                        .income(0)
+                        .outcome(500000)
+                        .dateUsed(LocalDateTime.of(2000, 1, 1, 1, 1, 1))
+                        .personReceived(received)
+                        .personInCharge(inCharge)
+                        .build());
+        }
+        budgetHistoryRepository.saveAll(histories);
+
+        //when
+        Page<BudgetHistoryDetailDto> page = budgetHistoryRepository.findAllByPageable(
+                PageRequest.of(1, 20, Direction.DESC, "dateUsed"));
+
+
+        //then
+        assertThat(page.getTotalElements()).isEqualTo(30);
+        assertThat(page.getNumberOfElements()).isEqualTo(10);
+        assertThat(page.getTotalPages()).isEqualTo(2);
+        assertThat(page.getContent().get(0)).extracting("title").isEqualTo("간식비21");
+    }
+}

--- a/resource-server/src/test/java/com/inhabas/api/domain/budget/repository/BudgetHistoryRepositoryTest.java
+++ b/resource-server/src/test/java/com/inhabas/api/domain/budget/repository/BudgetHistoryRepositoryTest.java
@@ -1,17 +1,10 @@
 package com.inhabas.api.domain.budget.repository;
 
-import static com.inhabas.api.domain.member.domain.MemberTest.MEMBER1;
-import static com.inhabas.api.domain.member.domain.MemberTest.MEMBER2;
-import static org.assertj.core.api.Assertions.assertThat;
-
 import com.inhabas.api.domain.budget.domain.BudgetHistory;
 import com.inhabas.api.domain.budget.dto.BudgetHistoryDetailDto;
 import com.inhabas.api.domain.member.domain.entity.Member;
 import com.inhabas.api.domain.member.domain.valueObject.MemberId;
 import com.inhabas.testAnnotataion.DefaultDataJpaTest;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,6 +13,15 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort.Direction;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.inhabas.api.domain.member.domain.MemberTest.MEMBER1;
+import static com.inhabas.api.domain.member.domain.MemberTest.MEMBER2;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @DefaultDataJpaTest
 public class BudgetHistoryRepositoryTest {
@@ -41,22 +43,51 @@ public class BudgetHistoryRepositoryTest {
         inCharge = member2.getId();
     }
 
-    @DisplayName("예산 내역 페이지 객체를 가져온다.")
+    @DisplayName("예산 내역을 하나 조회한다.")
     @Test
-    public void fetchBudgetHistoryPageTest() {
+    public void fetchOneBudgetHistoryTest() {
         //given
-        List<BudgetHistory> histories = new ArrayList<>();
-        for (int i = 1; i < 31; i++) {
-            histories.add(
+        BudgetHistory history = budgetHistoryRepository.save(
                 BudgetHistory.builder()
-                        .title("간식비"+i)
-                        .details("과자"+i)
+                        .title("간식비")
+                        .details("과자")
                         .income(0)
                         .outcome(500000)
                         .dateUsed(LocalDateTime.of(2000, 1, 1, 1, 1, 1))
                         .personReceived(received)
                         .personInCharge(inCharge)
                         .build());
+        Integer id = (Integer) ReflectionTestUtils.getField(history, "id");
+
+        //when
+        BudgetHistoryDetailDto budgetHistoryDetailDto = budgetHistoryRepository.findDtoById(id)
+                .orElseThrow();
+
+        //then
+        assertThat(budgetHistoryDetailDto.getDateCreated()).isNotNull();
+        assertThat(budgetHistoryDetailDto.getTitle()).isEqualTo("간식비");
+        assertThat(budgetHistoryDetailDto.getOutcome()).isEqualTo(500000);
+        assertThat(budgetHistoryDetailDto.getReceivedMemberName()).isEqualTo("유동현");
+        assertThat(budgetHistoryDetailDto.getMemberNameInCharge()).isEqualTo("김민겸");
+    }
+
+    @DisplayName("예산 내역 페이지 객체를 가져온다.")
+    @Test
+    public void fetchBudgetHistoryPageTest() {
+
+        //given
+        List<BudgetHistory> histories = new ArrayList<>();
+        for (int i = 1; i < 31; i++) {
+            histories.add(
+                    BudgetHistory.builder()
+                            .title("간식비" + i)
+                            .details("과자" + i)
+                            .income(0)
+                            .outcome(500000)
+                            .dateUsed(LocalDateTime.of(2000, 1, 1, 1, 1, 1))
+                            .personReceived(received)
+                            .personInCharge(inCharge)
+                            .build());
         }
         budgetHistoryRepository.saveAll(histories);
 

--- a/resource-server/src/test/java/com/inhabas/api/domain/budget/usecase/BudgetHistoryServiceTest.java
+++ b/resource-server/src/test/java/com/inhabas/api/domain/budget/usecase/BudgetHistoryServiceTest.java
@@ -200,7 +200,7 @@ public class BudgetHistoryServiceTest {
         budgetHistoryService.searchHistoryList(null, Pageable.ofSize(15));
 
         //then
-        then(repository).should(times(1)).search(any(),any());
+        then(repository).should(times(1)).search(any(), any());
     }
 
     @DisplayName("회계내역을 id 로 조회한다.")
@@ -233,5 +233,16 @@ public class BudgetHistoryServiceTest {
         then(repository).should(times(1)).findDtoById(anyInt());
     }
 
+    @DisplayName("기록이 존재하는 년도를 모두 가져온다.")
+    @Test
+    public void fetchAllYearOfHistoryTest() {
+        //given
+        given(repository.findAllYear()).willReturn(null);
 
+        //when
+        budgetHistoryService.getAllYearOfHistory();
+
+        //then
+        then(repository).should(times(1)).findAllYear();
+    }
 }

--- a/resource-server/src/test/java/com/inhabas/api/domain/budget/usecase/BudgetHistoryServiceTest.java
+++ b/resource-server/src/test/java/com/inhabas/api/domain/budget/usecase/BudgetHistoryServiceTest.java
@@ -1,20 +1,13 @@
 package com.inhabas.api.domain.budget.usecase;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.times;
-
 import com.inhabas.api.domain.budget.HistoryCannotModifiableException;
 import com.inhabas.api.domain.budget.NotFoundBudgetHistoryException;
 import com.inhabas.api.domain.budget.domain.BudgetHistory;
 import com.inhabas.api.domain.budget.dto.BudgetHistoryCreateForm;
+import com.inhabas.api.domain.budget.dto.BudgetHistoryDetailDto;
 import com.inhabas.api.domain.budget.dto.BudgetHistoryModifyForm;
 import com.inhabas.api.domain.budget.repository.BudgetHistoryRepository;
 import com.inhabas.api.domain.member.domain.valueObject.MemberId;
-import java.time.LocalDateTime;
-import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,6 +18,15 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
 
 @ExtendWith(MockitoExtension.class)
 public class BudgetHistoryServiceTest {
@@ -188,7 +190,7 @@ public class BudgetHistoryServiceTest {
         then(repository).should(times(1)).findById(anyInt());
     }
 
-    @DisplayName("회계내역을 출력한다.")
+    @DisplayName("회계내역을 한 페이지를 출력한다.")
     @Test
     public void getListOfBudgetHistoryTest() {
         //given
@@ -200,4 +202,36 @@ public class BudgetHistoryServiceTest {
         //then
         then(repository).should(times(1)).findAllByPageable(any());
     }
+
+    @DisplayName("회계내역을 id 로 조회한다.")
+    @Test
+    public void getOneBudgetHistoryTest() {
+        //given
+        given(repository.findDtoById(anyInt()))
+                .willReturn(Optional.of(new BudgetHistoryDetailDto(
+                        null, null, null, null, null, null,
+                        null, null, null, null,
+                        null)));
+
+        //when
+        budgetHistoryService.getHistory(2);
+
+        //then
+        then(repository).should(times(1)).findDtoById(anyInt());
+    }
+
+    @DisplayName("id 에 해당하는 회계내역이 없는 경우, NotFoundException을 던진다.")
+    @Test
+    public void cannotFindBudgetHistoryFindById() {
+        //given
+        given(repository.findDtoById(anyInt())).willReturn(Optional.empty());
+
+        //when
+        Assertions.assertThrows(NotFoundBudgetHistoryException.class,
+                () -> budgetHistoryService.getHistory(2));
+
+        then(repository).should(times(1)).findDtoById(anyInt());
+    }
+
+
 }

--- a/resource-server/src/test/java/com/inhabas/api/domain/budget/usecase/BudgetHistoryServiceTest.java
+++ b/resource-server/src/test/java/com/inhabas/api/domain/budget/usecase/BudgetHistoryServiceTest.java
@@ -1,0 +1,189 @@
+package com.inhabas.api.domain.budget.usecase;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+import com.inhabas.api.domain.budget.HistoryCannotModifiableException;
+import com.inhabas.api.domain.budget.NotFoundBudgetHistoryException;
+import com.inhabas.api.domain.budget.domain.BudgetHistory;
+import com.inhabas.api.domain.budget.dto.BudgetHistoryCreateForm;
+import com.inhabas.api.domain.budget.dto.BudgetHistoryModifyForm;
+import com.inhabas.api.domain.budget.repository.BudgetHistoryRepository;
+import com.inhabas.api.domain.member.domain.valueObject.MemberId;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+public class BudgetHistoryServiceTest {
+
+    @InjectMocks
+    private BudgetHistoryServiceImpl budgetHistoryService;
+
+    @Mock
+    private BudgetHistoryRepository repository;
+
+    @DisplayName("총무가 회계내역을 추가한다.")
+    @Test
+    public void createBudgetHistoryTest() {
+
+        //given
+        BudgetHistoryCreateForm form = new BudgetHistoryCreateForm(
+                LocalDateTime.of(2000, 1, 1, 1, 1, 1),
+                "서버운영비", "aws 작년 서버비용", 12345678, 0, 500000);
+        MemberId cfo = new MemberId(12171652);
+        given(repository.save(any(BudgetHistory.class))).willReturn(null);
+
+        //when
+        budgetHistoryService.createNewHistory(form, cfo);
+
+        //then
+        then(repository).should(times(1)).save(any(BudgetHistory.class));
+    }
+
+    @DisplayName("총무가 회계내역을 수정한다.")
+    @Test
+    public void modifyBudgetHistoryTest() {
+        //when
+        MemberId CFO = new MemberId(12171652);
+        BudgetHistory history = BudgetHistory.builder()
+                .title("서버 운영비")
+                .details("작년 aws 운영 비용")
+                .income(0)
+                .outcome(500000)
+                .dateUsed(LocalDateTime.of(2000, 1, 1, 1, 1, 1))
+                .personReceived(new MemberId(10982942))
+                .personInCharge(CFO)
+                .build();
+        ReflectionTestUtils.setField(history, "id", 1);
+        given(repository.findById(any())).willReturn(Optional.of(history));
+
+        //when
+        BudgetHistoryModifyForm form = new BudgetHistoryModifyForm(
+                LocalDateTime.of(2000, 1, 1, 1, 1, 1),
+                "서버운영비", "aws 작년 서버비용", 12345678, 0, 500000, 1);
+        budgetHistoryService.modifyHistory(form, CFO);
+
+        //then
+        then(repository).should(times(1)).findById(any());
+        then(repository).should(times(1)).save(any(BudgetHistory.class));
+    }
+
+    @DisplayName("총무는 이전의 다른 총무가 작성한 내역을 수정할 수 없다.")
+    @Test
+    public void cannotModifyBudgetHistoryOfOtherCFO() {
+        //given
+        MemberId previousCFO = new MemberId(12171652);
+        MemberId currentCFO = new MemberId(99999999);
+        BudgetHistory history = BudgetHistory.builder()
+                .title("서버 운영비")
+                .details("작년 aws 운영 비용")
+                .income(0)
+                .outcome(500000)
+                .dateUsed(LocalDateTime.of(2000, 1, 1, 1, 1, 1))
+                .personReceived(new MemberId(10982942))
+                .personInCharge(previousCFO)
+                .build();
+        ReflectionTestUtils.setField(history, "id", 1);
+        given(repository.findById(any())).willReturn(Optional.of(history));
+
+        //when
+        BudgetHistoryModifyForm form = new BudgetHistoryModifyForm(
+                LocalDateTime.of(2000, 1, 1, 1, 1, 1),
+                "서버운영비", "aws 작년 서버비용", 12345678, 0, 500000, 1);
+        Assertions.assertThrows(AccessDeniedException.class,
+                () -> budgetHistoryService.modifyHistory(form, currentCFO));
+    }
+
+    @DisplayName("수정 시도할 때 히스토리 내역이 존재하지 않으면 오류를 던진다.")
+    @Test
+    public void raiseNotFoundExceptionWhenModifyingTest() {
+        //given
+        given(repository.findById(any())).willReturn(Optional.empty());
+
+        //when
+        BudgetHistoryModifyForm form = new BudgetHistoryModifyForm(
+                LocalDateTime.of(2000, 1, 1, 1, 1, 1),
+                "서버운영비", "aws 작년 서버비용", 12345678, 0, 500000, 1);
+        Assertions.assertThrows(NotFoundBudgetHistoryException.class,
+                () -> budgetHistoryService.modifyHistory(form, new MemberId(12171652)));
+    }
+
+    @DisplayName("총무가 회계 내역을 삭제한다.")
+    @Test
+    public void deleteBudgetHistoryTest() {
+        //given
+        MemberId CFO = new MemberId(12171652);
+        Integer historyId = 1;
+        BudgetHistory history = BudgetHistory.builder()
+                .title("서버 운영비")
+                .details("작년 aws 운영 비용")
+                .income(0)
+                .outcome(500000)
+                .dateUsed(LocalDateTime.of(2000, 1, 1, 1, 1, 1))
+                .personReceived(new MemberId(10982942))
+                .personInCharge(CFO)
+                .build();
+        ReflectionTestUtils.setField(history, "id", historyId);
+        given(repository.findById(any())).willReturn(Optional.of(history));
+
+        //when
+        budgetHistoryService.deleteHistory(historyId, CFO);
+
+        //then
+        then(repository).should(times(1)).findById(anyInt());
+        then(repository).should(times(1)).deleteById(anyInt());
+    }
+
+    @DisplayName("이전의 다른 담당자가 작성했던 기록은 삭제할 수 없다.")
+    @Test
+    public void cannotDeleteBudgetHistoryTest() {
+        //given
+        MemberId previousCFO = new MemberId(12171652);
+        MemberId currentCFO = new MemberId(99999999);
+        Integer historyId = 1;
+        BudgetHistory history = BudgetHistory.builder()
+                .title("서버 운영비")
+                .details("작년 aws 운영 비용")
+                .income(0)
+                .outcome(500000)
+                .dateUsed(LocalDateTime.of(2000, 1, 1, 1, 1, 1))
+                .personReceived(new MemberId(10982942))
+                .personInCharge(previousCFO)
+                .build();
+        ReflectionTestUtils.setField(history, "id", historyId);
+        given(repository.findById(any())).willReturn(Optional.of(history));
+
+        //when
+        Assertions.assertThrows(HistoryCannotModifiableException.class,
+                ()->budgetHistoryService.deleteHistory(historyId, currentCFO));
+
+        //then
+        then(repository).should(times(1)).findById(anyInt());
+    }
+
+    @DisplayName("존재하지 않는 기록을 삭제하려고 하면 예외를 던진다.")
+    @Test
+    public void raiseNotFoundExceptionWhenDeletingTest() {
+        //given
+        given(repository.findById(any())).willReturn(Optional.empty());
+
+        //when
+        Assertions.assertThrows(NotFoundBudgetHistoryException.class,
+                () -> budgetHistoryService.deleteHistory(1, new MemberId(12171652)));
+
+        //then
+        then(repository).should(times(1)).findById(anyInt());
+    }
+}

--- a/resource-server/src/test/java/com/inhabas/api/domain/budget/usecase/BudgetHistoryServiceTest.java
+++ b/resource-server/src/test/java/com/inhabas/api/domain/budget/usecase/BudgetHistoryServiceTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -167,7 +168,7 @@ public class BudgetHistoryServiceTest {
 
         //when
         Assertions.assertThrows(HistoryCannotModifiableException.class,
-                ()->budgetHistoryService.deleteHistory(historyId, currentCFO));
+                () -> budgetHistoryService.deleteHistory(historyId, currentCFO));
 
         //then
         then(repository).should(times(1)).findById(anyInt());
@@ -185,5 +186,18 @@ public class BudgetHistoryServiceTest {
 
         //then
         then(repository).should(times(1)).findById(anyInt());
+    }
+
+    @DisplayName("회계내역을 출력한다.")
+    @Test
+    public void getListOfBudgetHistoryTest() {
+        //given
+        given(repository.findAllByPageable(any())).willReturn(null);
+
+        //when
+        budgetHistoryService.getHistoryList(Pageable.ofSize(15));
+
+        //then
+        then(repository).should(times(1)).findAllByPageable(any());
     }
 }

--- a/resource-server/src/test/java/com/inhabas/api/domain/budget/usecase/BudgetHistoryServiceTest.java
+++ b/resource-server/src/test/java/com/inhabas/api/domain/budget/usecase/BudgetHistoryServiceTest.java
@@ -194,13 +194,13 @@ public class BudgetHistoryServiceTest {
     @Test
     public void getListOfBudgetHistoryTest() {
         //given
-        given(repository.findAllByPageable(any())).willReturn(null);
+        given(repository.search(any(), any())).willReturn(null);
 
         //when
-        budgetHistoryService.getHistoryList(Pageable.ofSize(15));
+        budgetHistoryService.searchHistoryList(null, Pageable.ofSize(15));
 
         //then
-        then(repository).should(times(1)).findAllByPageable(any());
+        then(repository).should(times(1)).search(any(),any());
     }
 
     @DisplayName("회계내역을 id 로 조회한다.")

--- a/resource-server/src/test/java/com/inhabas/api/domain/comment/usecase/CommentServiceTest.java
+++ b/resource-server/src/test/java/com/inhabas/api/domain/comment/usecase/CommentServiceTest.java
@@ -1,25 +1,16 @@
 package com.inhabas.api.domain.comment.usecase;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.isA;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-
 import com.inhabas.api.domain.board.domain.NormalBoard;
 import com.inhabas.api.domain.board.domain.NormalBoardTest;
 import com.inhabas.api.domain.board.repository.NormalBoardRepository;
 import com.inhabas.api.domain.comment.domain.Comment;
+import com.inhabas.api.domain.comment.dto.CommentSaveDto;
+import com.inhabas.api.domain.comment.dto.CommentUpdateDto;
 import com.inhabas.api.domain.comment.repository.CommentRepository;
 import com.inhabas.api.domain.member.domain.MemberTest;
 import com.inhabas.api.domain.member.domain.entity.Member;
 import com.inhabas.api.domain.member.domain.valueObject.MemberId;
 import com.inhabas.api.domain.member.repository.MemberRepository;
-import com.inhabas.api.domain.comment.dto.CommentSaveDto;
-import com.inhabas.api.domain.comment.dto.CommentUpdateDto;
-import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -28,6 +19,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class CommentServiceTest {
@@ -64,7 +62,7 @@ public class CommentServiceTest {
                 .willReturn(new Comment(any(Integer.class), "이야 이게 댓글 기능이라고??"));
 
         //given
-        CommentSaveDto newComment = new CommentSaveDto(memberId, "이야 이게 댓글 기능이라고??", 12);
+        CommentSaveDto newComment = new CommentSaveDto(12171652, "이야 이게 댓글 기능이라고??", 12);
 
         //when
         Integer returnId = commentService.create(newComment);

--- a/resource-server/src/test/java/com/inhabas/api/web/BudgetHistoryControllerTest.java
+++ b/resource-server/src/test/java/com/inhabas/api/web/BudgetHistoryControllerTest.java
@@ -1,16 +1,5 @@
 package com.inhabas.api.web;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.groups.Tuple.tuple;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.times;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import com.inhabas.api.domain.budget.usecase.BudgetHistoryService;
 import com.inhabas.testAnnotataion.NoSecureWebMvcTest;
 import org.junit.jupiter.api.DisplayName;
@@ -20,6 +9,15 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @NoSecureWebMvcTest(BudgetHistoryController.class)
 public class BudgetHistoryControllerTest {
@@ -132,7 +130,7 @@ public class BudgetHistoryControllerTest {
         then(budgetHistoryService).should(times(1)).deleteHistory(any(), any());
     }
 
-    @DisplayName("회계내역 정보를 불러온다.")
+    @DisplayName("회계내역 리스트를 불러온다.")
     @Test
     public void getListOfBudgetHistoryListTest() throws Exception {
 
@@ -140,5 +138,16 @@ public class BudgetHistoryControllerTest {
                 .andExpect(status().isOk());
 
         then(budgetHistoryService).should(times(1)).getHistoryList(any());
+    }
+
+    @DisplayName("회계내역 정보 하나를 불러온다.")
+    @Test
+    public void fetchOneBudgetHistoryTest() throws Exception {
+
+        mockMvc.perform(get("/budget/history")
+                .param("id", "2"))
+                .andExpect(status().isOk());
+
+        then(budgetHistoryService).should(times(1)).getHistory(anyInt());
     }
 }

--- a/resource-server/src/test/java/com/inhabas/api/web/BudgetHistoryControllerTest.java
+++ b/resource-server/src/test/java/com/inhabas/api/web/BudgetHistoryControllerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -39,10 +40,10 @@ public class BudgetHistoryControllerTest {
         //when
         Exception resolvedException =
                 mockMvc.perform(post("/budget/history/create")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(jsonOfCreationForm))
-                .andExpect(status().isBadRequest())
-                .andReturn().getResolvedException();
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(jsonOfCreationForm))
+                        .andExpect(status().isBadRequest())
+                        .andReturn().getResolvedException();
 
         //then
         MethodArgumentNotValidException validException = (MethodArgumentNotValidException) resolvedException;
@@ -131,5 +132,13 @@ public class BudgetHistoryControllerTest {
         then(budgetHistoryService).should(times(1)).deleteHistory(any(), any());
     }
 
+    @DisplayName("회계내역 정보를 불러온다.")
+    @Test
+    public void getListOfBudgetHistoryListTest() throws Exception {
 
+        mockMvc.perform(get("/budget/history/get"))
+                .andExpect(status().isOk());
+
+        then(budgetHistoryService).should(times(1)).getHistoryList(any());
+    }
 }

--- a/resource-server/src/test/java/com/inhabas/api/web/BudgetHistoryControllerTest.java
+++ b/resource-server/src/test/java/com/inhabas/api/web/BudgetHistoryControllerTest.java
@@ -1,0 +1,135 @@
+package com.inhabas.api.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.inhabas.api.domain.budget.usecase.BudgetHistoryService;
+import com.inhabas.testAnnotataion.NoSecureWebMvcTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+
+@NoSecureWebMvcTest(BudgetHistoryController.class)
+public class BudgetHistoryControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private BudgetHistoryService budgetHistoryService;
+
+
+    @DisplayName("예산내역 생성 시 form validation 을 통과하지 못한다.")
+    @Test
+    public void historyCreationFormTest() throws Exception {
+        //given
+        String jsonOfCreationForm = "{\"date_used\":\"2999-01-01T01:01:00\",\"title\":\" \",\"details\":\"aws 작년 비용\",\"person_received\":12171652,\"income\":-1,\"outcome\":-1}";
+
+        //when
+        Exception resolvedException =
+                mockMvc.perform(post("/budget/history/create")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonOfCreationForm))
+                .andExpect(status().isBadRequest())
+                .andReturn().getResolvedException();
+
+        //then
+        MethodArgumentNotValidException validException = (MethodArgumentNotValidException) resolvedException;
+        assert validException != null;
+        assertThat(validException.getFieldErrorCount()).isEqualTo(4);
+        assertThat(validException.getFieldErrors())
+                .extracting("defaultMessage", "field")
+                .contains(
+                        tuple("must not be blank", "title"),
+                        tuple("must be greater than or equal to 0", "income"),
+                        tuple("must be greater than or equal to 0", "outcome"),
+                        tuple("must be a past date", "dateUsed"));
+
+        then(budgetHistoryService).should(times(0)).createNewHistory(any(), any());
+    }
+
+    @DisplayName("예산내역 생성 시 validation 을 통과한다.")
+    @Test
+    public void budgetCreationFormWillPassValidationTest() throws Exception {
+        //given
+        String jsonOfCreationForm = "{\"date_used\":\"2000-01-01T01:01:00\",\"title\":\"서버 운영비\",\"details\":\"aws 작년 비용\",\"person_received\":12171652,\"income\":0,\"outcome\":500000}";
+
+        //when
+        mockMvc.perform(post("/budget/history/create")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonOfCreationForm))
+                .andExpect(status().isNoContent());
+
+        then(budgetHistoryService).should(times(1)).createNewHistory(any(), any());
+    }
+
+    @DisplayName("예산내역 생성 시 form validation 을 통과하지 못한다.")
+    @Test
+    public void historyModificationFormTest() throws Exception {
+        //given
+        String jsonOfCreationForm = "{\"id\":1, \"date_used\":\"2999-01-01T01:01:00\",\"title\":\" \",\"details\":\"aws 작년 비용\",\"person_received\":12171652,\"income\":-1,\"outcome\":-1}";
+
+        //when
+        Exception resolvedException =
+                mockMvc.perform(put("/budget/history/update")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(jsonOfCreationForm))
+                        .andExpect(status().isBadRequest())
+                        .andReturn().getResolvedException();
+
+        //then
+        MethodArgumentNotValidException validException = (MethodArgumentNotValidException) resolvedException;
+        assert validException != null;
+        assertThat(validException.getFieldErrorCount()).isEqualTo(4);
+        assertThat(validException.getFieldErrors())
+                .extracting("defaultMessage", "field")
+                .contains(
+                        tuple("must not be blank", "title"),
+                        tuple("must be greater than or equal to 0", "income"),
+                        tuple("must be greater than or equal to 0", "outcome"),
+                        tuple("must be a past date", "dateUsed"));
+
+        then(budgetHistoryService).should(times(0)).modifyHistory(any(), any());
+    }
+
+    @DisplayName("예산내역 수정 시 validation 을 통과한다.")
+    @Test
+    public void budgetModificationFormWillPassValidationTest() throws Exception {
+        //given
+        String jsonOfModificationForm = "{\"id\":1,\"date_used\":\"2000-01-01T01:01:00\",\"title\":\"서버 운영비\",\"details\":\"aws 작년 비용\",\"person_received\":12171652,\"income\":0,\"outcome\":500000}";
+
+        //when
+        mockMvc.perform(put("/budget/history/update")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonOfModificationForm))
+                .andExpect(status().isNoContent());
+
+        then(budgetHistoryService).should(times(1)).modifyHistory(any(), any());
+    }
+
+    @DisplayName("예산내역 삭제 시 validation 을 통과한다.")
+    @Test
+    public void budgetDeletionFormWillPassValidationTest() throws Exception {
+        //given
+
+        //when
+        mockMvc.perform(delete("/budget/history/delete")
+                        .param("id", "1"))
+                .andExpect(status().isNoContent());
+
+        then(budgetHistoryService).should(times(1)).deleteHistory(any(), any());
+    }
+
+
+}

--- a/resource-server/src/test/java/com/inhabas/api/web/BudgetHistoryControllerTest.java
+++ b/resource-server/src/test/java/com/inhabas/api/web/BudgetHistoryControllerTest.java
@@ -145,9 +145,19 @@ public class BudgetHistoryControllerTest {
     public void fetchOneBudgetHistoryTest() throws Exception {
 
         mockMvc.perform(get("/budget/history")
-                .param("id", "2"))
+                        .param("id", "2"))
                 .andExpect(status().isOk());
 
         then(budgetHistoryService).should(times(1)).getHistory(anyInt());
+    }
+
+    @DisplayName("회계 내역의 모든 연도를 불러온다.")
+    @Test
+    public void fetchAllYearsOfHistoryTest() throws Exception {
+
+        mockMvc.perform(get("/budget/history/years"))
+                .andExpect(status().isOk());
+
+        then(budgetHistoryService).should(times(1)).getAllYearOfHistory();
     }
 }

--- a/resource-server/src/test/java/com/inhabas/api/web/BudgetHistoryControllerTest.java
+++ b/resource-server/src/test/java/com/inhabas/api/web/BudgetHistoryControllerTest.java
@@ -134,10 +134,10 @@ public class BudgetHistoryControllerTest {
     @Test
     public void getListOfBudgetHistoryListTest() throws Exception {
 
-        mockMvc.perform(get("/budget/history/get"))
+        mockMvc.perform(get("/budget/history/search"))
                 .andExpect(status().isOk());
 
-        then(budgetHistoryService).should(times(1)).getHistoryList(any());
+        then(budgetHistoryService).should(times(1)).searchHistoryList(any(), any());
     }
 
     @DisplayName("회계내역 정보 하나를 불러온다.")

--- a/resource-server/src/test/java/com/inhabas/api/web/BudgetHistoryControllerTest.java
+++ b/resource-server/src/test/java/com/inhabas/api/web/BudgetHistoryControllerTest.java
@@ -37,7 +37,7 @@ public class BudgetHistoryControllerTest {
 
         //when
         Exception resolvedException =
-                mockMvc.perform(post("/budget/history/create")
+                mockMvc.perform(post("/budget/history")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(jsonOfCreationForm))
                         .andExpect(status().isBadRequest())
@@ -65,7 +65,7 @@ public class BudgetHistoryControllerTest {
         String jsonOfCreationForm = "{\"date_used\":\"2000-01-01T01:01:00\",\"title\":\"서버 운영비\",\"details\":\"aws 작년 비용\",\"person_received\":12171652,\"income\":0,\"outcome\":500000}";
 
         //when
-        mockMvc.perform(post("/budget/history/create")
+        mockMvc.perform(post("/budget/history")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(jsonOfCreationForm))
                 .andExpect(status().isNoContent());
@@ -81,7 +81,7 @@ public class BudgetHistoryControllerTest {
 
         //when
         Exception resolvedException =
-                mockMvc.perform(put("/budget/history/update")
+                mockMvc.perform(put("/budget/history")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(jsonOfCreationForm))
                         .andExpect(status().isBadRequest())
@@ -109,7 +109,7 @@ public class BudgetHistoryControllerTest {
         String jsonOfModificationForm = "{\"id\":1,\"date_used\":\"2000-01-01T01:01:00\",\"title\":\"서버 운영비\",\"details\":\"aws 작년 비용\",\"person_received\":12171652,\"income\":0,\"outcome\":500000}";
 
         //when
-        mockMvc.perform(put("/budget/history/update")
+        mockMvc.perform(put("/budget/history")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(jsonOfModificationForm))
                 .andExpect(status().isNoContent());
@@ -123,8 +123,7 @@ public class BudgetHistoryControllerTest {
         //given
 
         //when
-        mockMvc.perform(delete("/budget/history/delete")
-                        .param("id", "1"))
+        mockMvc.perform(delete("/budget/history/2"))
                 .andExpect(status().isNoContent());
 
         then(budgetHistoryService).should(times(1)).deleteHistory(any(), any());
@@ -144,8 +143,7 @@ public class BudgetHistoryControllerTest {
     @Test
     public void fetchOneBudgetHistoryTest() throws Exception {
 
-        mockMvc.perform(get("/budget/history")
-                        .param("id", "2"))
+        mockMvc.perform(get("/budget/history/2"))
                 .andExpect(status().isOk());
 
         then(budgetHistoryService).should(times(1)).getHistory(anyInt());

--- a/resource-server/src/test/java/com/inhabas/api/web/CommentControllerTest.java
+++ b/resource-server/src/test/java/com/inhabas/api/web/CommentControllerTest.java
@@ -1,26 +1,12 @@
 package com.inhabas.api.web;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doThrow;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.inhabas.api.domain.member.domain.valueObject.MemberId;
 import com.inhabas.api.domain.comment.dto.CommentDetailDto;
 import com.inhabas.api.domain.comment.dto.CommentSaveDto;
 import com.inhabas.api.domain.comment.dto.CommentUpdateDto;
 import com.inhabas.api.domain.comment.usecase.CommentServiceImpl;
+import com.inhabas.api.domain.member.domain.valueObject.MemberId;
 import com.inhabas.testAnnotataion.NoSecureWebMvcTest;
-import java.time.LocalDateTime;
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -32,6 +18,18 @@ import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @NoSecureWebMvcTest(CommentController.class)
 public class CommentControllerTest {
@@ -81,7 +79,7 @@ public class CommentControllerTest {
     @Test
     void createNewComment() throws Exception {
         //given
-        String jsonRequest = "{\"writerId\":12171652,\"contents\":\"아싸 1등\",\"boardId\":13}";
+        String jsonRequest = "{\"writerId\":12171652,\"contents\":\"아싸 1등\",\"board_id\":13}";
         Integer newCommentId = 1;
         given(commentService.create(any(CommentSaveDto.class))).willReturn(newCommentId);
 

--- a/resource-server/src/test/java/com/inhabas/api/web/MenuControllerTest.java
+++ b/resource-server/src/test/java/com/inhabas/api/web/MenuControllerTest.java
@@ -1,5 +1,19 @@
 package com.inhabas.api.web;
 
+import com.inhabas.api.domain.menu.domain.valueObject.MenuId;
+import com.inhabas.api.domain.menu.domain.valueObject.MenuType;
+import com.inhabas.api.domain.menu.dto.MenuDto;
+import com.inhabas.api.domain.menu.dto.MenuGroupDto;
+import com.inhabas.api.domain.menu.usecase.MenuService;
+import com.inhabas.testAnnotataion.NoSecureWebMvcTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -8,19 +22,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import com.inhabas.api.domain.menu.domain.valueObject.MenuId;
-import com.inhabas.api.domain.menu.domain.valueObject.MenuType;
-import com.inhabas.api.domain.menu.dto.MenuDto;
-import com.inhabas.api.domain.menu.dto.MenuGroupDto;
-import com.inhabas.api.domain.menu.usecase.MenuService;
-import com.inhabas.testAnnotataion.NoSecureWebMvcTest;
-import java.util.List;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.web.servlet.MockMvc;
 
 @NoSecureWebMvcTest(MenuController.class)
 public class MenuControllerTest {
@@ -40,7 +41,7 @@ public class MenuControllerTest {
         mvc.perform(get("/menu/all"))
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(content().string("[{\"id\":1,\"groupName\":\"IBAS\",\"menuList\":[{\"id\":6,\"priority\":1,\"name\":\"ë\u008F\u0099ì\u0095\u0084ë¦¬ ì\u0086\u008Cê°\u009C\",\"type\":\"INTRODUCE\",\"description\":\"\"}]}]"))
+                .andExpect(content().string("[{\"id\":1,\"group_name\":\"IBAS\",\"menu_list\":[{\"id\":6,\"priority\":1,\"name\":\"ë\u008F\u0099ì\u0095\u0084ë¦¬ ì\u0086\u008Cê°\u009C\",\"type\":\"INTRODUCE\",\"description\":\"\"}]}]"))
                 .andReturn();
 
         then(menuService).should(times(1)).getAllMenuInfo();

--- a/resource-server/src/test/resources/application.yml
+++ b/resource-server/src/test/resources/application.yml
@@ -17,6 +17,11 @@ spring:
       enabled: always
   jackson:
     property-naming-strategy: SNAKE_CASE
+  data:
+    web:
+      pageable:
+        one-indexed-parameters: true # 페이지네이션 index 1부터 시작.
+        default-page-size: 15
   jpa:
     show-sql: true
     defer-datasource-initialization: false

--- a/resource-server/src/test/resources/application.yml
+++ b/resource-server/src/test/resources/application.yml
@@ -15,6 +15,8 @@ spring:
   output:
     ansi:
       enabled: always
+  jackson:
+    property-naming-strategy: SNAKE_CASE
   jpa:
     show-sql: true
     defer-datasource-initialization: false
@@ -76,6 +78,3 @@ logging:
     org.springframwork.web.client: DEBUG
     org.hibernate.type: trace
 
-authenticate:
-  oauth2-success-handle-url: /login/test-success
-  oauth2-failure-handle-url: /login/test-fail


### PR DESCRIPTION
- `BudgetHistory` 도메인 생성
- CRUD 기능 추가.
- 페이지네이션 기능 추가
- 총무만 `POST`, `PUT`, `DELETE` 가능하도록 제한.
- 회계 내역 연도별 검색 기능
- 회계 내역이 존재하는 연도 목록 구하는 기능 

resolve #132