### PR TITLE
[bugfix/#143] 게시글 조회 관련 버그 수정

### DIFF
--- a/resource-server/src/main/java/com/inhabas/api/domain/board/repository/NormalBoardRepositoryImpl.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/board/repository/NormalBoardRepositoryImpl.java
@@ -33,16 +33,24 @@ public class NormalBoardRepositoryImpl implements NormalBoardRepositoryCustom {
                         normalBoard.updated))
                 .from(normalBoard)
                 .innerJoin(member).on(eqMemberId())
-                .where(menuEq(menuId))
+                .where(eqMenuId(menuId))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
 
-        return new PageImpl<>(results, pageable, results.size());
+        return new PageImpl<>(results, pageable, this.getCount(menuId));
     }
 
-    private BooleanExpression menuEq(MenuId menuId) {
+    private BooleanExpression eqMenuId(MenuId menuId) {
         return normalBoard.menuId.eq(menuId);
+    }
+
+    // 캐시 필요함.
+    private Integer getCount(MenuId menuId) {
+        return queryFactory.selectFrom(normalBoard)
+                .where(eqMenuId(menuId))
+                .fetch()
+                .size();
     }
 
     @Override

--- a/resource-server/src/main/java/com/inhabas/api/domain/board/repository/NormalBoardRepositoryImpl.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/board/repository/NormalBoardRepositoryImpl.java
@@ -32,7 +32,7 @@ public class NormalBoardRepositoryImpl implements NormalBoardRepositoryCustom {
                         normalBoard.created,
                         normalBoard.updated))
                 .from(normalBoard)
-                .innerJoin(member).on(normalBoard.writerId.eq(member.id))
+                .innerJoin(member).on(eqMemberId())
                 .where(menuEq(menuId))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -57,10 +57,14 @@ public class NormalBoardRepositoryImpl implements NormalBoardRepositoryCustom {
                         normalBoard.created,
                         normalBoard.updated))
                 .from(normalBoard)
-                .innerJoin(member).on(normalBoard.writerId.eq(member.id))
-                .limit(1)
+                .innerJoin(member).on(eqMemberId())
+                .where(normalBoard.id.eq(id))
                 .fetchOne();
 
         return Optional.ofNullable(target);
+    }
+
+    private BooleanExpression eqMemberId() {
+        return normalBoard.writerId.eq(member.id);
     }
 }

--- a/resource-server/src/test/java/com/inhabas/api/domain/board/repository/NormalBoardRepositoryTest.java
+++ b/resource-server/src/test/java/com/inhabas/api/domain/board/repository/NormalBoardRepositoryTest.java
@@ -90,17 +90,18 @@ public class NormalBoardRepositoryTest {
     public void findDtoById() {
         //given
         boardRepository.save(FREE_BOARD);
+        boardRepository.save(NOTICE_BOARD);
 
         //when
-        BoardDto find = boardRepository.findDtoById(FREE_BOARD.getId())
+        BoardDto find = boardRepository.findDtoById(NOTICE_BOARD.getId())
                 .orElseThrow(EntityNotFoundException::new);
 
         //then
         assertAll(
-                () -> assertThat(find.getId()).isEqualTo(FREE_BOARD.getId()),
-                () -> assertThat(find.getTitle()).isEqualTo(FREE_BOARD.getTitle()),
-                () -> assertThat(find.getContents()).isEqualTo(FREE_BOARD.getContents()),
-                () -> assertThat(find.getMenuId()).isEqualTo(FREE_BOARD.getMenuId()),
+                () -> assertThat(find.getId()).isEqualTo(NOTICE_BOARD.getId()),
+                () -> assertThat(find.getTitle()).isEqualTo(NOTICE_BOARD.getTitle()),
+                () -> assertThat(find.getContents()).isEqualTo(NOTICE_BOARD.getContents()),
+                () -> assertThat(find.getMenuId()).isEqualTo(NOTICE_BOARD.getMenuId()),
                 () -> assertThat(find.getWriterName()).isEqualTo(writer.getName())
         );
     }


### PR DESCRIPTION
1. id 로 특정 게시글 조회할 때, where 절 추가
2. 게시글 목록 조회시 총 페이지 수가 1개로 나오던 것 -> 카운트 쿼리 추가해서 수정. 추후 캐시 필요

resolve #143 