### PR TITLE
[invalid/#153] 예산지원 신청글 수정 시 대기상태로 변경

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -21,6 +21,7 @@ jobs:
       with:
         host: ${{ secrets.IBAS_DEV_HOST }}
         username: ${{ secrets.IBAS_DEV_USERNAME }}
+        passphrase: ${{ secrets.IBAS_DEV_PASSWORD }}
         key: ${{ secrets.IBAS_DEV_SSH_KEY }}
         # port: ${{ secrets.PORT }} # default : 22
         script: |

--- a/resource-server/src/main/java/com/inhabas/api/domain/budget/domain/BudgetSupportApplication.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/budget/domain/BudgetSupportApplication.java
@@ -73,6 +73,7 @@ public class BudgetSupportApplication extends BaseEntity {
         this.details = new Details(details);
         this.outcome = new Price(outcome);
         this.applicantAccount = new ApplicantAccount(account);
+        this.status = ApplicationStatus.WAITING;
     }
 
     public boolean cannotModifiableBy(MemberId currentApplicant) {

--- a/resource-server/src/test/java/com/inhabas/api/securityConfig/RoleHierarchyTest.java
+++ b/resource-server/src/test/java/com/inhabas/api/securityConfig/RoleHierarchyTest.java
@@ -82,13 +82,13 @@ public class RoleHierarchyTest {
 
     private void 공지사항_게시판_접근() throws Exception {
         mockMvc.perform(get("/boards")
-                        .param("menuId", "6"))
+                        .param("menu_id", "6"))
                 .andExpect(status().isOk());
     }
 
     private void 공지사항_게시판_접근_불가() throws Exception {
         mockMvc.perform(get("/boards")
-                        .param("menuId", "6"))
+                        .param("menu_id", "6"))
                 .andExpect(status().isForbidden());
     }
 }

--- a/resource-server/src/test/java/com/inhabas/api/web/BoardControllerTest.java
+++ b/resource-server/src/test/java/com/inhabas/api/web/BoardControllerTest.java
@@ -21,7 +21,6 @@ import com.inhabas.api.domain.board.dto.UpdateBoardDto;
 import com.inhabas.api.domain.board.usecase.BoardService;
 import com.inhabas.api.domain.member.domain.MemberService;
 import com.inhabas.api.domain.menu.domain.valueObject.MenuId;
-import com.inhabas.api.web.converter.MenuIdConverter;
 import com.inhabas.testAnnotataion.NoSecureWebMvcTest;
 import com.inhabas.testAnnotataion.WithMockJwtAuthenticationToken;
 import java.time.LocalDateTime;
@@ -32,7 +31,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -41,7 +39,6 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 @NoSecureWebMvcTest(BoardController.class)
-@Import(MenuIdConverter.IntegerToMenuIdConverter.class)
 public class BoardControllerTest {
 
     @Autowired
@@ -73,7 +70,6 @@ public class BoardControllerTest {
         // when
         mvc.perform(post("/board")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .param("userId", "1")
                         .content(objectMapper.writeValueAsString(saveBoardDto)))
                 .andExpect(status().isCreated())
                 .andExpect(content().string("1"));


### PR DESCRIPTION
예산 지원 신청글 수정할 때,

- 이미 승인 완료되었는데, 수정하면 안되고
- 승인 거절 당한 후 수정하면, 승인 대기로 변경하는 것이 더 바람직해보임.

위의 두 경우 모두, 원글을 수정하면 승인대기상태로 변경되게끔하면 문제없음.

resolve #153