### PR TITLE
[bugfix/Inhabas#268] 내가 쓴 게시글 조회에서 예산신청 표시되는 문제 오류 수정

### DIFF
--- a/resource-server/src/main/java/com/inhabas/api/domain/myInfo/repository/MyInfoRepositoryImpl.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/myInfo/repository/MyInfoRepositoryImpl.java
@@ -3,14 +3,14 @@ package com.inhabas.api.domain.myInfo.repository;
 import static com.inhabas.api.domain.board.domain.QBaseBoard.baseBoard;
 import static com.inhabas.api.domain.budget.domain.QBudgetSupportApplication.budgetSupportApplication;
 import static com.inhabas.api.domain.comment.domain.QComment.comment;
+import static com.inhabas.api.domain.menu.domain.valueObject.MenuType.BUDGET_ACCOUNT;
+import static com.inhabas.api.domain.menu.domain.valueObject.MenuType.BUDGET_SUPPORT;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
 
-import com.inhabas.api.domain.budget.domain.BudgetHistory;
-import com.inhabas.api.domain.budget.domain.BudgetSupportApplication;
 import com.inhabas.api.domain.comment.domain.Comment;
 import com.inhabas.api.domain.myInfo.dto.MyBoardDto;
 import com.inhabas.api.domain.myInfo.dto.MyBudgetSupportApplicationDto;
@@ -41,9 +41,9 @@ public class MyInfoRepositoryImpl implements MyInfoRepositoryCustom {
                 .writer
                 .id
                 .eq(memberId)
-                // budgetSupportApplication, budgetHistory은 게시판 조회 범주에서 제외
-                .and(baseBoard.instanceOf(BudgetSupportApplication.class).not())
-                .and(baseBoard.instanceOf(BudgetHistory.class).not()))
+                // MenuType을 기반으로 BUDGET_APPLICATION과 BUDGET_HISTORY 게시글 제외
+                .and(baseBoard.menu.type.ne(BUDGET_SUPPORT))
+                .and(baseBoard.menu.type.ne(BUDGET_ACCOUNT)))
         .orderBy(baseBoard.dateCreated.desc())
         .fetch();
   }

--- a/resource-server/src/main/java/com/inhabas/api/domain/myInfo/repository/MyInfoRepositoryImpl.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/myInfo/repository/MyInfoRepositoryImpl.java
@@ -41,7 +41,7 @@ public class MyInfoRepositoryImpl implements MyInfoRepositoryCustom {
                 .writer
                 .id
                 .eq(memberId)
-                // MenuType을 기반으로 BUDGET_APPLICATION과 BUDGET_HISTORY 게시글 제외
+                // MenuType을 기반으로 BUDGET_SUPPORT과 BUDGET_ACCOUNT 게시글 제외
                 .and(baseBoard.menu.type.ne(BUDGET_SUPPORT))
                 .and(baseBoard.menu.type.ne(BUDGET_ACCOUNT)))
         .orderBy(baseBoard.dateCreated.desc())


### PR DESCRIPTION
내가 쓴 게시글 조회에서 예산신청 표시되는 문제 오류 수정 PR을 올렸음에도 불구하고 문제가 지속되어서 원인을 파악해보니, 예산지원신청에서 상태가 COMPLETED가 되면서 회계내역으로 게시글 정보가 넘어가면서 문제가 발생한 것 같습니다.
우선 03.29에 올린 머지된 PR 기능이 잘 작동하는지 테스트 해보고 이상이 여전히 있으면 이 PR을 적용시킬 예정입니다.