### PR TITLE
[refactor/Inhabas#271] 메뉴 설명 사이즈 변경

### DIFF
--- a/resource-server/src/main/java/com/inhabas/api/domain/menu/domain/valueObject/Description.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/menu/domain/valueObject/Description.java
@@ -13,10 +13,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Description {
 
-  @Column(name = "DESCRIPTION", length = 50)
+  @Column(name = "DESCRIPTION", length = 100)
   private String value;
 
-  @Transient private final int MAX_LENGTH = 50;
+  @Transient private final int MAX_LENGTH = 100;
 
   public Description(String value) {
     if (validate(value)) this.value = value;


### PR DESCRIPTION
명예의 전당 메뉴 설명이 50(byte) 제한에 잘리고 있어 메뉴 설명 사이즈 100바이트까지로 확장했습니다. 데이터 컬럼에서도 늘렸습니다.