### PR TITLE
[bugfix/Inhabas#300] 게시판 조회시 writerID 추가 및 dDay계산 기능 수정

### DIFF
--- a/resource-server/src/main/java/com/inhabas/api/domain/contest/dto/ContestBoardDetailDto.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/contest/dto/ContestBoardDetailDto.java
@@ -38,9 +38,9 @@ public class ContestBoardDetailDto {
 
   @NotNull private FileDownloadDto thumbnail;
 
-  private List<FileDownloadDto> images;
+  @NotNull private List<FileDownloadDto> images;
 
-  private List<FileDownloadDto> otherFiles;
+  @NotNull private List<FileDownloadDto> otherFiles;
 
   @NotNull
   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")

--- a/resource-server/src/main/java/com/inhabas/api/domain/contest/dto/ContestBoardDto.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/contest/dto/ContestBoardDto.java
@@ -2,6 +2,10 @@ package com.inhabas.api.domain.contest.dto;
 
 import java.time.LocalDateTime;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
+
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,11 +19,18 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @NoArgsConstructor
 public class ContestBoardDto {
   // 공모전 게시판 id
-  private Long id;
-  private Long contestFieldId;
-  private String title;
-  private String topic;
-  private String association;
+
+  @NotNull @Positive private Long id;
+
+  @NotNull private Long contestFieldId;
+
+  @NotBlank private String title;
+
+  @NotNull private Long writerId;
+
+  @NotNull private String topic;
+
+  @NotNull private String association;
 
   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
   @Schema(type = "string", example = "2024-11-01T00:00:00")
@@ -37,6 +48,7 @@ public class ContestBoardDto {
   public ContestBoardDto(
       Long id,
       Long contestFieldId,
+      Long writerId,
       String title,
       String topic,
       String association,
@@ -46,6 +58,7 @@ public class ContestBoardDto {
       FileDownloadDto thumbnail) {
     this.id = id;
     this.contestFieldId = contestFieldId;
+    this.writerId = writerId;
     this.title = title;
     this.topic = topic;
     this.association = association;

--- a/resource-server/src/main/java/com/inhabas/api/domain/contest/repository/ContestBoardRepositoryImpl.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/contest/repository/ContestBoardRepositoryImpl.java
@@ -55,11 +55,13 @@ public class ContestBoardRepositoryImpl implements ContestBoardRepositoryCustom 
               return ContestBoardDto.builder()
                   .id(board.getId())
                   .contestFieldId(board.getContestField().getId())
+                  .writerId(board.getWriter().getId())
                   .title(board.getTitle())
                   .topic(board.getTopic())
                   .association(board.getAssociation())
                   .dateContestStart(board.getDateContestStart())
                   .dateContestEnd(board.getDateContestEnd())
+                  .dDay(board.getDDay())
                   .thumbnail(classifiedFiles.getThumbnail())
                   .build();
             })

--- a/resource-server/src/main/java/com/inhabas/api/domain/contest/usecase/ContestBoardServiceImpl.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/contest/usecase/ContestBoardServiceImpl.java
@@ -74,6 +74,7 @@ public class ContestBoardServiceImpl implements ContestBoardService {
         .contestFieldId(contestBoard.getContestField().getId())
         .title(contestBoard.getTitle())
         .content(contestBoard.getContent())
+        .writerId(contestBoard.getWriter().getId())
         .writerName(contestBoard.getWriter().getName())
         .association(contestBoard.getAssociation())
         .topic(contestBoard.getTopic())


### PR DESCRIPTION
공모전 게시판 조회시 dDay가 null값으로 나오고, writerID도 조회 안되는 문제가 있어서 해결했습니다.

build test, swagger test 완료 했습니다.