### PR TITLE
[Bugfix/#326] 회계내역 사용자 조회 오류

### DIFF
--- a/module-auth/src/main/java/com/inhabas/api/auth/domain/oauth2/member/dto/ApprovedMemberSummaryDto.java
+++ b/module-auth/src/main/java/com/inhabas/api/auth/domain/oauth2/member/dto/ApprovedMemberSummaryDto.java
@@ -13,6 +13,9 @@ import org.hibernate.validator.constraints.Length;
 @Getter
 @NoArgsConstructor
 public class ApprovedMemberSummaryDto {
+
+  @NotNull private Long id;
+
   @NotBlank
   @Length(max = 50)
   private String name;
@@ -29,7 +32,13 @@ public class ApprovedMemberSummaryDto {
 
   @Builder
   public ApprovedMemberSummaryDto(
-      String name, String studentId, MemberType memberType, Integer generation, String major) {
+      Long id,
+      String name,
+      String studentId,
+      MemberType memberType,
+      Integer generation,
+      String major) {
+    this.id = id;
     this.name = name;
     this.studentId = studentId;
     this.memberType = memberType;

--- a/module-auth/src/main/java/com/inhabas/api/auth/domain/oauth2/member/repository/MemberRepository.java
+++ b/module-auth/src/main/java/com/inhabas/api/auth/domain/oauth2/member/repository/MemberRepository.java
@@ -18,7 +18,7 @@ public interface MemberRepository extends JpaRepository<Member, Long>, MemberRep
 
   List<Member> findAllByIbasInformation_IsHOF(boolean IsHOF);
 
-  Optional<Member> findByStudentId_IdAndName_Value(String studentId, String name);
+  Optional<Member> findByIdAndStudentId_IdAndName_Value(Long id, String studentId, String name);
 
   // OAuth
   boolean existsByProviderAndUid(OAuth2Provider provider, UID uid);

--- a/resource-server/src/main/java/com/inhabas/api/domain/budget/dto/BudgetHistoryCreateForm.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/budget/dto/BudgetHistoryCreateForm.java
@@ -35,6 +35,8 @@ public class BudgetHistoryCreateForm {
 
   @NotBlank private String details;
 
+  private Long memberIdReceived;
+
   private String memberStudentIdReceived;
 
   private String memberNameReceived;
@@ -54,6 +56,7 @@ public class BudgetHistoryCreateForm {
       LocalDateTime dateUsed,
       String title,
       String details,
+      Long memberIdReceived,
       String memberStudentIdReceived,
       String memberNameReceived,
       Integer income,
@@ -62,6 +65,7 @@ public class BudgetHistoryCreateForm {
     this.dateUsed = dateUsed;
     this.title = title;
     this.details = details;
+    this.memberIdReceived = memberIdReceived;
     this.memberStudentIdReceived = memberStudentIdReceived;
     this.memberNameReceived = memberNameReceived;
     this.income = income;
@@ -75,6 +79,7 @@ public class BudgetHistoryCreateForm {
   public boolean isIncome() {
     return this.income > ZERO
         && this.outcome == 0
+        && this.memberIdReceived == null
         && this.memberNameReceived == null
         && this.memberStudentIdReceived == null;
   }
@@ -82,6 +87,7 @@ public class BudgetHistoryCreateForm {
   public boolean isOutcome() {
     return this.outcome > ZERO
         && this.income == 0
+        && this.memberIdReceived != null
         && this.memberNameReceived != null
         && this.memberStudentIdReceived != null;
   }

--- a/resource-server/src/main/java/com/inhabas/api/domain/budget/usecase/BudgetHistoryServiceImpl.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/budget/usecase/BudgetHistoryServiceImpl.java
@@ -47,8 +47,10 @@ public class BudgetHistoryServiceImpl implements BudgetHistoryService {
     } else if (form.isOutcome()) {
       memberReceived =
           memberRepository
-              .findByStudentId_IdAndName_Value(
-                  form.getMemberStudentIdReceived(), form.getMemberNameReceived())
+              .findByIdAndStudentId_IdAndName_Value(
+                  form.getMemberIdReceived(),
+                  form.getMemberStudentIdReceived(),
+                  form.getMemberNameReceived())
               .orElseThrow(MemberNotFoundException::new);
     } else {
       throw new InvalidInputException();
@@ -79,8 +81,10 @@ public class BudgetHistoryServiceImpl implements BudgetHistoryService {
     } else if (form.isOutcome()) {
       memberReceived =
           memberRepository
-              .findByStudentId_IdAndName_Value(
-                  form.getMemberStudentIdReceived(), form.getMemberNameReceived())
+              .findByIdAndStudentId_IdAndName_Value(
+                  form.getMemberIdReceived(),
+                  form.getMemberStudentIdReceived(),
+                  form.getMemberNameReceived())
               .orElseThrow(MemberNotFoundException::new);
     } else {
       throw new InvalidInputException();

--- a/resource-server/src/main/java/com/inhabas/api/domain/member/usecase/MemberManageServiceImpl.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/member/usecase/MemberManageServiceImpl.java
@@ -112,6 +112,7 @@ public class MemberManageServiceImpl implements MemberManageService {
         .map(
             member ->
                 ApprovedMemberSummaryDto.builder()
+                    .id(member.getId())
                     .name(member.getName())
                     .studentId(member.getStudentId())
                     .memberType(member.getSchoolInformation().getMemberType())

--- a/resource-server/src/test/java/com/inhabas/api/domain/budget/usecase/BudgetHistoryServiceTest.java
+++ b/resource-server/src/test/java/com/inhabas/api/domain/budget/usecase/BudgetHistoryServiceTest.java
@@ -105,6 +105,7 @@ public class BudgetHistoryServiceTest {
             .dateUsed(LocalDateTime.now())
             .title("title")
             .details("details")
+            .memberIdReceived(1L)
             .memberStudentIdReceived("12171707")
             .memberNameReceived("조승현")
             .income(0)
@@ -125,7 +126,7 @@ public class BudgetHistoryServiceTest {
             .build();
 
     given(memberRepository.findById(any())).willReturn(Optional.of(secretary));
-    given(memberRepository.findByStudentId_IdAndName_Value(any(), any()))
+    given(memberRepository.findByIdAndStudentId_IdAndName_Value(any(), any(), any()))
         .willReturn(Optional.of(memberReceived));
     given(menuRepository.findById(anyInt())).willReturn(Optional.of(menu));
     given(boardFileRepository.getAllByIdInAndUploader(anyList(), any())).willReturn(List.of(file));
@@ -153,6 +154,7 @@ public class BudgetHistoryServiceTest {
             LocalDateTime.now().minusDays(1L),
             "title",
             "details",
+            1L,
             "12171234",
             "유동현",
             0,
@@ -173,7 +175,7 @@ public class BudgetHistoryServiceTest {
             .writtenBy(secretary, BudgetHistory.class);
     ReflectionTestUtils.setField(budgetHistory, "id", 1L);
     given(memberRepository.findById(any())).willReturn(Optional.of(secretary));
-    given(memberRepository.findByStudentId_IdAndName_Value(any(), any()))
+    given(memberRepository.findByIdAndStudentId_IdAndName_Value(any(), any(), any()))
         .willReturn(Optional.of(memberReceived));
     given(budgetHistoryRepository.findById(any())).willReturn(Optional.of(budgetHistory));
     given(boardFileRepository.getAllByIdInAndUploader(anyList(), any())).willReturn(List.of(file));

--- a/resource-server/src/test/java/com/inhabas/api/web/MemberControllerTest.java
+++ b/resource-server/src/test/java/com/inhabas/api/web/MemberControllerTest.java
@@ -170,7 +170,7 @@ public class MemberControllerTest {
     // given
     List<ApprovedMemberSummaryDto> dtoList = new ArrayList<>();
     ApprovedMemberSummaryDto dto1 =
-        new ApprovedMemberSummaryDto("홍길동", "12171707", UNDERGRADUATE, 1, "컴퓨터공학과");
+        new ApprovedMemberSummaryDto(1L, "홍길동", "12171707", UNDERGRADUATE, 1, "컴퓨터공학과");
     dtoList.add(dto1);
 
     given(memberManageService.getAllApprovedMembersBySearchAndRole(any())).willReturn(dtoList);


### PR DESCRIPTION
비활동 멤버 조회에 id값 추가
회계내역 작성에 필요한 값 memberIdReceived 추가