### PR TITLE
[bugfix/#337] 생성날짜, 수정날짜 시간차 오류

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
         ipv4_address: 172.18.0.6
     ports:
       - "8888:8888"
+    environment:
+      TZ: Asia/Seoul
     entrypoint: [ "java", "-jar", "app.jar" ]
 
   prod1:
@@ -19,7 +21,8 @@ services:
     ports:
       - "8080:8080"
     environment:
-      - SPRING_PROFILES_ACTIVE=prod1
+      SPRING_PROFILES_ACTIVE: prod1
+      TZ: Asia/Seoul
     entrypoint: ["java", "-jar", "app.jar", "--spring.profiles.active=prod1"]
 
   prod2:
@@ -31,7 +34,8 @@ services:
     ports:
       - "8081:8081"
     environment:
-      - SPRING_PROFILES_ACTIVE=prod2
+      SPRING_PROFILES_ACTIVE: prod2
+      TZ: Asia/Seoul
     entrypoint: ["java", "-jar", "app.jar", "--spring.profiles.active=prod2"]
 
   dev1:
@@ -43,7 +47,8 @@ services:
     ports:
       - "8082:8082"
     environment:
-      - SPRING_PROFILES_ACTIVE=dev1
+      SPRING_PROFILES_ACTIVE: dev1
+      TZ: Asia/Seoul
     entrypoint: ["java", "-jar", "app.jar", "--spring.profiles.active=dev1"]
 
   dev2:
@@ -55,7 +60,8 @@ services:
     ports:
       - "8083:8083"
     environment:
-      - SPRING_PROFILES_ACTIVE=dev2
+      SPRING_PROFILES_ACTIVE: dev2
+      TZ: Asia/Seoul
     entrypoint: ["java", "-jar", "app.jar", "--spring.profiles.active=dev2"]
 
 

--- a/resource-server/src/main/java/com/inhabas/api/domain/BaseEntity.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/BaseEntity.java
@@ -18,11 +18,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 public abstract class BaseEntity {
 
   @CreatedDate
-  @Column(
-      nullable = false,
-      updatable = false,
-      insertable = false,
-      columnDefinition = "DATETIME(0) DEFAULT CURRENT_TIMESTAMP")
+  @Column(nullable = false, updatable = false, columnDefinition = "DATETIME(0)")
   private LocalDateTime dateCreated;
 
   @CreatedDate


### PR DESCRIPTION
기존 문제
dateCreated는 mysql 서버 시간, dateUpdated는 컨테이너 Java 서버 시간으로 설정되어 있어 시간차가 있었습니다. 심지어 컨테이너에 timezone을 설정해주지 않아 한국 시간대로 설정되어 있지 않았습니다.

객체 생성 시간으로 통일하였고 container에 timezone을 설정해주었습니다.