### PR TITLE
[bugfix/#344] 첨부파일이 필요한 게시판에서 생성, 수정할 때 첨부파일 빈 값으로 보내는 경우 검증로직 추가

### DIFF
--- a/resource-server/src/main/java/com/inhabas/api/domain/budget/dto/BudgetApplicationRegisterForm.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/budget/dto/BudgetApplicationRegisterForm.java
@@ -8,6 +8,7 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Past;
 import javax.validation.constraints.PositiveOrZero;
+import javax.validation.constraints.Size;
 
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -39,6 +40,8 @@ public class BudgetApplicationRegisterForm {
 
   @NotBlank private String account;
 
+  @NotNull
+  @Size(min = 1)
   private List<String> files = new ArrayList<>();
 
   @Builder

--- a/resource-server/src/main/java/com/inhabas/api/domain/club/dto/SaveClubActivityDto.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/club/dto/SaveClubActivityDto.java
@@ -4,6 +4,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -17,6 +19,8 @@ public class SaveClubActivityDto {
 
   @NotBlank private String content;
 
+  @NotNull
+  @Size(min = 1)
   private List<String> files = new ArrayList<>();
 
   @Builder

--- a/resource-server/src/main/java/com/inhabas/api/domain/contest/dto/SaveContestBoardDto.java
+++ b/resource-server/src/main/java/com/inhabas/api/domain/contest/dto/SaveContestBoardDto.java
@@ -7,6 +7,7 @@ import java.util.List;
 import javax.validation.constraints.Future;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -50,6 +51,8 @@ public class SaveContestBoardDto {
   @Future(message = "이미 모집기간이 종료된 공모전은 등록할 수 없습니다.")
   private LocalDateTime dateContestEnd;
 
+  @NotNull
+  @Size(min = 1)
   private List<String> files = new ArrayList<>();
 
   @Builder

--- a/resource-server/src/main/java/com/inhabas/api/web/ClubActivityController.java
+++ b/resource-server/src/main/java/com/inhabas/api/web/ClubActivityController.java
@@ -3,6 +3,8 @@ package com.inhabas.api.web;
 import java.net.URI;
 import java.util.List;
 
+import javax.validation.Valid;
+
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.data.domain.PageImpl;
@@ -91,7 +93,7 @@ public class ClubActivityController {
   @PreAuthorize(
       "@boardSecurityChecker.checkMenuAccess(2, T(com.inhabas.api.domain.board.usecase.BoardSecurityChecker).CREATE_BOARD)")
   public ResponseEntity<Void> writeClubActivity(
-      @Authenticated Long memberId, @RequestBody SaveClubActivityDto form) {
+      @Authenticated Long memberId, @Valid @RequestBody SaveClubActivityDto form) {
     Long newClubActivityId = clubActivityService.writeClubActivity(memberId, form);
     URI location =
         ServletUriComponentsBuilder.fromCurrentRequest()
@@ -168,7 +170,7 @@ public class ClubActivityController {
   public ResponseEntity<ClubActivityDto> updateClubActivity(
       @Authenticated Long memberId,
       @PathVariable Long boardId,
-      @RequestBody SaveClubActivityDto form) {
+      @Valid @RequestBody SaveClubActivityDto form) {
     clubActivityService.updateClubActivity(boardId, form, memberId);
     return ResponseEntity.noContent().build();
   }

--- a/resource-server/src/test/java/com/inhabas/api/domain/club/dto/SaveClubActivityDtoTest.java
+++ b/resource-server/src/test/java/com/inhabas/api/domain/club/dto/SaveClubActivityDtoTest.java
@@ -1,8 +1,8 @@
 package com.inhabas.api.domain.club.dto;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.Arrays;
 import java.util.Set;
 
 import javax.validation.ConstraintViolation;
@@ -36,7 +36,7 @@ public class SaveClubActivityDtoTest {
   public void validationTest() {
     // given
     SaveClubActivityDto saveClubActivityDto =
-        SaveClubActivityDto.builder().title("").content("").files(null).build();
+        SaveClubActivityDto.builder().title("").content("").files(Arrays.asList("fileId")).build();
 
     // when
     Set<ConstraintViolation<SaveClubActivityDto>> violations =

--- a/resource-server/src/test/java/com/inhabas/api/domain/contest/dto/SaveContestBoardDtoTest.java
+++ b/resource-server/src/test/java/com/inhabas/api/domain/contest/dto/SaveContestBoardDtoTest.java
@@ -2,6 +2,7 @@ package com.inhabas.api.domain.contest.dto;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
@@ -37,7 +38,16 @@ public class SaveContestBoardDtoTest {
   public void FieldsAreNullError() {
     // given
     SaveContestBoardDto saveContestBoardDto =
-        new SaveContestBoardDto(null, null, null, null, null, null, null, null);
+        SaveContestBoardDto.builder()
+            .contestFieldId(null)
+            .title(null)
+            .content(null)
+            .association(null)
+            .topic(null)
+            .dateContestStart(null)
+            .dateContestEnd(null)
+            .files(null)
+            .build();
 
     // when
     Set<ConstraintViolation<SaveContestBoardDto>> violations =
@@ -62,7 +72,16 @@ public class SaveContestBoardDtoTest {
   public void FieldsAreBlankedError() {
     // given
     SaveContestBoardDto saveContestBoardDto =
-        new SaveContestBoardDto(null, " ", " ", " ", " ", null, null, null);
+        SaveContestBoardDto.builder()
+            .contestFieldId(null)
+            .title(" ")
+            .content(" ")
+            .association(" ")
+            .topic(" ")
+            .dateContestStart(null)
+            .dateContestEnd(null)
+            .files(Arrays.asList())
+            .build();
 
     // when
     Set<ConstraintViolation<SaveContestBoardDto>> violations =
@@ -87,15 +106,17 @@ public class SaveContestBoardDtoTest {
   public void InputsAreExceededError() {
     // given
     SaveContestBoardDto saveContestBoardDto =
-        new SaveContestBoardDto(
-            1L,
-            "title".repeat(20) + ".",
-            "content! Cucumber paste has to have a sun-dried, chilled sauerkraut component.",
-            "Assoc".repeat(20) + ".",
-            "topic".repeat(100) + ".",
-            LocalDateTime.of(2022, 1, 1, 0, 0, 0),
-            LocalDateTime.of(9999, 3, 3, 0, 0, 0),
-            null);
+        SaveContestBoardDto.builder()
+            .contestFieldId(1L)
+            .title("title".repeat(20) + ".")
+            .content(
+                "content! Cucumber paste has to have a sun-dried, chilled sauerkraut component.")
+            .association("Assoc".repeat(20) + ".")
+            .topic("topic".repeat(100) + ".")
+            .dateContestStart(LocalDateTime.of(2022, 1, 1, 0, 0, 0))
+            .dateContestEnd(LocalDateTime.of(9999, 3, 3, 0, 0, 0))
+            .files(Arrays.asList("fileId"))
+            .build();
 
     // when
     Set<ConstraintViolation<SaveContestBoardDto>> violations =
@@ -115,15 +136,16 @@ public class SaveContestBoardDtoTest {
   public void DeadlineIsOutdatedError() {
     // given
     SaveContestBoardDto saveContestBoardDto =
-        new SaveContestBoardDto(
-            1L,
-            "title",
-            "content",
-            "association",
-            "topic",
-            LocalDateTime.of(2022, 1, 1, 0, 0, 0),
-            LocalDateTime.of(2022, 2, 1, 0, 0, 0),
-            null);
+        SaveContestBoardDto.builder()
+            .contestFieldId(1L)
+            .title("title")
+            .content("content")
+            .association("association")
+            .topic("topic")
+            .dateContestStart(LocalDateTime.of(2022, 1, 1, 0, 0, 0))
+            .dateContestEnd(LocalDateTime.of(2022, 2, 1, 0, 0, 0))
+            .files(Arrays.asList("fileId"))
+            .build();
 
     // when
     Set<ConstraintViolation<SaveContestBoardDto>> violations =

--- a/resource-server/src/test/java/com/inhabas/api/web/BudgetApplicationControllerTest.java
+++ b/resource-server/src/test/java/com/inhabas/api/web/BudgetApplicationControllerTest.java
@@ -15,6 +15,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -109,6 +110,7 @@ public class BudgetApplicationControllerTest {
             .dateUsed(LocalDateTime.now())
             .outcome(10000)
             .account("123-123-123")
+            .files(Arrays.asList("fileId"))
             .build();
 
     given(budgetApplicationService.registerApplication(any(), any())).willReturn(1L);
@@ -155,6 +157,7 @@ public class BudgetApplicationControllerTest {
             .dateUsed(LocalDateTime.now())
             .outcome(10000)
             .account("123-123-123")
+            .files(Arrays.asList("fileId"))
             .build();
     doNothing().when(budgetApplicationService).updateApplication(any(), any(), any());
 
@@ -194,6 +197,7 @@ public class BudgetApplicationControllerTest {
             .dateUsed(LocalDateTime.now())
             .outcome(10000)
             .account("123-123-123")
+            .files(Arrays.asList("fileId"))
             .build();
     doThrow(NotFoundException.class)
         .when(budgetApplicationService)

--- a/resource-server/src/test/java/com/inhabas/api/web/ClubActivityControllerTest.java
+++ b/resource-server/src/test/java/com/inhabas/api/web/ClubActivityControllerTest.java
@@ -14,6 +14,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -152,7 +153,12 @@ public class ClubActivityControllerTest {
   @Test
   void writeClubActivity() throws Exception {
     // given
-    SaveClubActivityDto form = new SaveClubActivityDto("title", "content", null);
+    SaveClubActivityDto form =
+        SaveClubActivityDto.builder()
+            .title("title")
+            .content("content")
+            .files(Arrays.asList("fileId"))
+            .build();
     given(clubActivityService.writeClubActivity(any(), any())).willReturn(1L);
 
     // when
@@ -175,7 +181,8 @@ public class ClubActivityControllerTest {
   @Test
   void writeClubActivity_Invalid_Input() throws Exception {
     // given
-    SaveClubActivityDto form = new SaveClubActivityDto("", "", null);
+    SaveClubActivityDto form =
+        SaveClubActivityDto.builder().title("").content("").files(Arrays.asList()).build();
     doThrow(InvalidInputException.class).when(clubActivityService).writeClubActivity(any(), any());
 
     // when
@@ -197,7 +204,13 @@ public class ClubActivityControllerTest {
   @Test
   void updateClubActivity() throws Exception {
     // given
-    SaveClubActivityDto form = new SaveClubActivityDto("title", "content", null);
+    SaveClubActivityDto form =
+        SaveClubActivityDto.builder()
+            .title("title")
+            .content("content")
+            .files(Arrays.asList("fileId"))
+            .build();
+
     doNothing().when(clubActivityService).updateClubActivity(any(), any(), any());
 
     // when then
@@ -235,7 +248,12 @@ public class ClubActivityControllerTest {
   @Test
   void updateClubActivity_Not_Found() throws Exception {
     // given
-    SaveClubActivityDto form = new SaveClubActivityDto("title", "content", null);
+    SaveClubActivityDto form =
+        SaveClubActivityDto.builder()
+            .title("title")
+            .content("content")
+            .files(Arrays.asList("fileId"))
+            .build();
 
     doThrow(NotFoundException.class)
         .when(clubActivityService)

--- a/resource-server/src/test/java/com/inhabas/api/web/ContestBoardControllerTest.java
+++ b/resource-server/src/test/java/com/inhabas/api/web/ContestBoardControllerTest.java
@@ -45,7 +45,6 @@ import org.junit.jupiter.api.Test;
 public class ContestBoardControllerTest {
 
   @Autowired private MockMvc mvc;
-
   @Autowired private ObjectMapper objectMapper;
 
   @MockBean private ContestBoardService contestBoardService;
@@ -213,6 +212,7 @@ public class ContestBoardControllerTest {
             .topic("good topic")
             .dateContestStart(LocalDateTime.now())
             .dateContestEnd(LocalDateTime.now().plusDays(10))
+            .files(List.of("fileId"))
             .build();
 
     // when
@@ -245,6 +245,7 @@ public class ContestBoardControllerTest {
             .topic("good topic")
             .dateContestStart(LocalDateTime.now())
             .dateContestEnd(LocalDateTime.now().plusDays(10))
+            .files(List.of("fileId"))
             .build();
 
     String saveContestBoardDtoJson = objectMapper.writeValueAsString(saveContestBoardDto);
@@ -280,6 +281,7 @@ public class ContestBoardControllerTest {
             .topic("good topic")
             .dateContestStart(LocalDateTime.now())
             .dateContestEnd(LocalDateTime.now().plusDays(10))
+            .files(List.of("fileId"))
             .build();
 
     // when then
@@ -308,6 +310,7 @@ public class ContestBoardControllerTest {
             .topic("good topic")
             .dateContestStart(LocalDateTime.now())
             .dateContestEnd(LocalDateTime.now().plusDays(10))
+            .files(List.of("fileId"))
             .build();
 
     // when
@@ -342,6 +345,7 @@ public class ContestBoardControllerTest {
             .topic("good topic")
             .dateContestStart(LocalDateTime.now())
             .dateContestEnd(LocalDateTime.now().plusDays(10))
+            .files(List.of("fileId"))
             .build();
 
     // when


### PR DESCRIPTION
동아리 활동, 공모전, 예산신청, 회계내역 게시판에서 게시판 생성, 수정하는 경우 Dto 첨부파일 부분에 `@NotNull`, `@Size(min = 1)` 어노테이션 추가하였고(이미 있는것은 그대로 뒀습니다.)

마찬가지로 각 Controller 에서 검증을 위해 `@RequestBody` 앞에  `@Valid` 어노테이션 추가했습니다.(이미 있는것은 그대로 뒀습니다.)

로컬에서 스웨거 테스트, 모든 테스트 통과 완료 확인했습니다.