### PR TITLE
[Refactor/InhaBas#168]CookieUtilsTest 코드 리팩토링

### DIFF
--- a/module-auth/src/test/java/com/inhabas/api/auth/domain/oauth2/cookie/CookieUtilsTest.java
+++ b/module-auth/src/test/java/com/inhabas/api/auth/domain/oauth2/cookie/CookieUtilsTest.java
@@ -1,40 +1,43 @@
 package com.inhabas.api.auth.domain.oauth2.cookie;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Optional;
 import java.util.Set;
 
 import javax.servlet.http.Cookie;
 
-import org.apache.commons.codec.binary.Base64;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 
-public class CookieUtilsTest {
+import org.apache.commons.codec.binary.Base64;
 
-  private static final String COOKIE_NAME = "myCookie";
-  private static final String COOKIE_CONTENTS = "hello";
-  private static final int COOKIE_MAX_AGE = 180;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class CookieUtilsTest {
 
   @DisplayName("request 에서 쿠키를 꺼낸다.")
   @Test
   public void resolveCookieFromRequest() {
     // given
-    MockHttpServletRequest request = createRequestWithCookie(COOKIE_NAME, COOKIE_CONTENTS, COOKIE_MAX_AGE);
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    Cookie cookie = new Cookie("myCookie", "hello");
+    cookie.setMaxAge(180);
+    request.setCookies(cookie);
 
     // when
-    Optional<Cookie> myCookie = CookieUtils.resolveCookie(request, COOKIE_NAME);
+    Optional<Cookie> myCookie = CookieUtils.resolveCookie(request, "myCookie");
 
     // then
-    assertThat(myCookie).isPresent()
-            .hasValueSatisfying(cookie -> {
-              assertThat(cookie.getValue()).isEqualTo(COOKIE_CONTENTS);
-              assertThat(cookie.getMaxAge()).isEqualTo(COOKIE_MAX_AGE);
-            });
+    assertThat(myCookie.isPresent()).isTrue();
+    assertThat(myCookie.get().getValue()).isEqualTo("hello");
+    assertThat(myCookie.get().getMaxAge()).isEqualTo(180);
   }
 
   @DisplayName("response 에 쿠키를 저장한다.")
@@ -42,18 +45,19 @@ public class CookieUtilsTest {
   public void saveCookieToResponse() {
     // given
     MockHttpServletResponse response = new MockHttpServletResponse();
+    String cookieName = "myCookie";
+    String cookieContents = "hello";
 
     // when
-    CookieUtils.setCookie(response, COOKIE_NAME, COOKIE_CONTENTS, COOKIE_MAX_AGE);
+    CookieUtils.setCookie(response, cookieName, cookieContents, 180);
 
     // then
-    Cookie resolvedCookie = response.getCookie(COOKIE_NAME);
-    assertThat(resolvedCookie).isNotNull()
-            .satisfies(cookie -> {
-              assertThat(cookie.getName()).isEqualTo(COOKIE_NAME);
-              assertThat(cookie.getValue()).isEqualTo(COOKIE_CONTENTS);
-              assertThat(cookie.getMaxAge()).isEqualTo(COOKIE_MAX_AGE);
-            });
+    Cookie resolvedCookie = response.getCookie(cookieName);
+    assert resolvedCookie != null;
+
+    assertThat(resolvedCookie.getName()).isEqualTo(cookieName);
+    assertThat(resolvedCookie.getValue()).isEqualTo(cookieContents);
+    assertThat(resolvedCookie.getMaxAge()).isEqualTo(180);
   }
 
   @DisplayName("request 에서 쿠키를 지운다.")
@@ -61,61 +65,38 @@ public class CookieUtilsTest {
   public void removeCookieOfRequest() {
     // given
     MockHttpServletResponse response = new MockHttpServletResponse();
-    MockHttpServletRequest request = createRequestWithCookie(COOKIE_NAME, COOKIE_CONTENTS, COOKIE_MAX_AGE);
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    Cookie cookie = new Cookie("myCookie", "hello");
+    cookie.setMaxAge(180);
+    request.setCookies(cookie);
 
     // when
-    CookieUtils.deleteCookie(request, response, COOKIE_NAME);
+    CookieUtils.deleteCookie(request, response, "myCookie");
 
     // then
-    Cookie deletedCookie = response.getCookie(COOKIE_NAME);
-    assertThat(deletedCookie).isNotNull()
-            .satisfies(cookie -> {
-              assertThat(cookie.getMaxAge()).isEqualTo(0);
-              assertThat(cookie.getValue()).isEqualTo("");
-            });
+    Cookie deletedCookie = response.getCookie("myCookie");
+    assert deletedCookie != null;
+    assertThat(deletedCookie.getMaxAge()).isEqualTo(0);
+    assertThat(deletedCookie.getValue()).isEqualTo("");
   }
 
   @DisplayName("성공적으로 serialize 한다.")
   @Test
-  public void serializingTest() throws Exception {
-    OAuth2AuthorizationRequest request = createOAuth2AuthorizationRequest();
-
-    // when
-    String serializedRequest = CookieUtils.serialize(request);
-
-    // then
-    assertThat(serializedRequest).matches(Base64::isBase64);
-  }
-
-  @DisplayName("성공적으로 deserialize 한다.")
-  @Test
-  public void deserializingTest() throws Exception {
-    OAuth2AuthorizationRequest originalRequest = createOAuth2AuthorizationRequest();
-    String serializedRequest = CookieUtils.serialize(originalRequest);
-    Cookie cookie = new Cookie("base64", serializedRequest);
-
-    // when
-    OAuth2AuthorizationRequest deserializedRequest = CookieUtils.deserialize(cookie, OAuth2AuthorizationRequest.class);
-
-    // then
-    assertThat(deserializedRequest).usingRecursiveComparison().isEqualTo(originalRequest);
-  }
-
-  private MockHttpServletRequest createRequestWithCookie(String name, String value, int maxAge) {
-    MockHttpServletRequest request = new MockHttpServletRequest();
-    Cookie cookie = new Cookie(name, value);
-    cookie.setMaxAge(maxAge);
-    request.setCookies(cookie);
-    return request;
-  }
-
-  static private OAuth2AuthorizationRequest createOAuth2AuthorizationRequest() throws Exception {
+  public void serializingTest()
+      throws InvocationTargetException, InstantiationException, IllegalAccessException,
+          NoSuchMethodException {
     // reflection
-    Constructor<?> constructor = OAuth2AuthorizationRequest.Builder.class.getDeclaredConstructor(AuthorizationGrantType.class);
+    Constructor<?> constructor =
+        OAuth2AuthorizationRequest.Builder.class.getDeclaredConstructor(
+            AuthorizationGrantType.class);
     constructor.setAccessible(true);
 
-    OAuth2AuthorizationRequest.Builder builder = (OAuth2AuthorizationRequest.Builder) constructor.newInstance(AuthorizationGrantType.AUTHORIZATION_CODE);
-    return builder
+    // given
+    OAuth2AuthorizationRequest.Builder builder =
+        (OAuth2AuthorizationRequest.Builder)
+            constructor.newInstance(AuthorizationGrantType.AUTHORIZATION_CODE);
+    OAuth2AuthorizationRequest request =
+        builder
             .authorizationUri("https://kauth.kakao.com/oauth/authorize")
             .clientId("1234")
             .redirectUri("http://localhost/api/login/oauth2/code/kakao")
@@ -124,5 +105,49 @@ public class CookieUtilsTest {
             .additionalParameters(java.util.Map.of())
             .attributes(java.util.Map.of("registration_id", "kakao"))
             .build();
+
+    // when
+    String serializedRequest = CookieUtils.serialize(request);
+
+    // then
+    assertTrue(Base64.isBase64(serializedRequest));
+  }
+
+  @DisplayName("성공적으로 deserialize 한다.")
+  @Test
+  public void deserializingTest()
+      throws NoSuchMethodException, InvocationTargetException, InstantiationException,
+          IllegalAccessException {
+
+    // reflection
+    Constructor<?> constructor =
+        OAuth2AuthorizationRequest.Builder.class.getDeclaredConstructor(
+            AuthorizationGrantType.class);
+    constructor.setAccessible(true);
+
+    // given
+    OAuth2AuthorizationRequest.Builder builder =
+        (OAuth2AuthorizationRequest.Builder)
+            constructor.newInstance(AuthorizationGrantType.AUTHORIZATION_CODE);
+    OAuth2AuthorizationRequest originalRequest =
+        builder
+            .authorizationUri("https://kauth.kakao.com/oauth/authorize")
+            .clientId("1234")
+            .redirectUri("http://localhost/api/login/oauth2/code/kakao")
+            .scopes(Set.of("gender", "profile_image", "account_email", "profile_nickname"))
+            .state("state1934")
+            .additionalParameters(java.util.Map.of())
+            .attributes(java.util.Map.of("registration_id", "kakao"))
+            .build();
+
+    String serializedRequest = CookieUtils.serialize(originalRequest);
+    Cookie cookie = new Cookie("base64", serializedRequest);
+
+    // when
+    OAuth2AuthorizationRequest deserializedRequest =
+        CookieUtils.deserialize(cookie, OAuth2AuthorizationRequest.class);
+
+    // then
+    assertThat(deserializedRequest).usingRecursiveComparison().isEqualTo(originalRequest);
   }
 }

--- a/module-auth/src/test/java/com/inhabas/api/auth/domain/oauth2/cookie/CookieUtilsTest.java
+++ b/module-auth/src/test/java/com/inhabas/api/auth/domain/oauth2/cookie/CookieUtilsTest.java
@@ -1,43 +1,40 @@
 package com.inhabas.api.auth.domain.oauth2.cookie;
-
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 import java.util.Optional;
 import java.util.Set;
 
 import javax.servlet.http.Cookie;
 
+import org.apache.commons.codec.binary.Base64;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 
-import org.apache.commons.codec.binary.Base64;
-
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
 public class CookieUtilsTest {
+
+  private static final String COOKIE_NAME = "myCookie";
+  private static final String COOKIE_CONTENTS = "hello";
+  private static final int COOKIE_MAX_AGE = 180;
 
   @DisplayName("request 에서 쿠키를 꺼낸다.")
   @Test
   public void resolveCookieFromRequest() {
     // given
-    MockHttpServletRequest request = new MockHttpServletRequest();
-    Cookie cookie = new Cookie("myCookie", "hello");
-    cookie.setMaxAge(180);
-    request.setCookies(cookie);
+    MockHttpServletRequest request = createRequestWithCookie(COOKIE_NAME, COOKIE_CONTENTS, COOKIE_MAX_AGE);
 
     // when
-    Optional<Cookie> myCookie = CookieUtils.resolveCookie(request, "myCookie");
+    Optional<Cookie> myCookie = CookieUtils.resolveCookie(request, COOKIE_NAME);
 
     // then
-    assertThat(myCookie.isPresent()).isTrue();
-    assertThat(myCookie.get().getValue()).isEqualTo("hello");
-    assertThat(myCookie.get().getMaxAge()).isEqualTo(180);
+    assertThat(myCookie).isPresent()
+            .hasValueSatisfying(cookie -> {
+              assertThat(cookie.getValue()).isEqualTo(COOKIE_CONTENTS);
+              assertThat(cookie.getMaxAge()).isEqualTo(COOKIE_MAX_AGE);
+            });
   }
 
   @DisplayName("response 에 쿠키를 저장한다.")
@@ -45,19 +42,18 @@ public class CookieUtilsTest {
   public void saveCookieToResponse() {
     // given
     MockHttpServletResponse response = new MockHttpServletResponse();
-    String cookieName = "myCookie";
-    String cookieContents = "hello";
 
     // when
-    CookieUtils.setCookie(response, cookieName, cookieContents, 180);
+    CookieUtils.setCookie(response, COOKIE_NAME, COOKIE_CONTENTS, COOKIE_MAX_AGE);
 
     // then
-    Cookie resolvedCookie = response.getCookie(cookieName);
-    assert resolvedCookie != null;
-
-    assertThat(resolvedCookie.getName()).isEqualTo(cookieName);
-    assertThat(resolvedCookie.getValue()).isEqualTo(cookieContents);
-    assertThat(resolvedCookie.getMaxAge()).isEqualTo(180);
+    Cookie resolvedCookie = response.getCookie(COOKIE_NAME);
+    assertThat(resolvedCookie).isNotNull()
+            .satisfies(cookie -> {
+              assertThat(cookie.getName()).isEqualTo(COOKIE_NAME);
+              assertThat(cookie.getValue()).isEqualTo(COOKIE_CONTENTS);
+              assertThat(cookie.getMaxAge()).isEqualTo(COOKIE_MAX_AGE);
+            });
   }
 
   @DisplayName("request 에서 쿠키를 지운다.")
@@ -65,72 +61,61 @@ public class CookieUtilsTest {
   public void removeCookieOfRequest() {
     // given
     MockHttpServletResponse response = new MockHttpServletResponse();
-    MockHttpServletRequest request = new MockHttpServletRequest();
-    Cookie cookie = new Cookie("myCookie", "hello");
-    cookie.setMaxAge(180);
-    request.setCookies(cookie);
+    MockHttpServletRequest request = createRequestWithCookie(COOKIE_NAME, COOKIE_CONTENTS, COOKIE_MAX_AGE);
 
     // when
-    CookieUtils.deleteCookie(request, response, "myCookie");
+    CookieUtils.deleteCookie(request, response, COOKIE_NAME);
 
     // then
-    Cookie deletedCookie = response.getCookie("myCookie");
-    assert deletedCookie != null;
-    assertThat(deletedCookie.getMaxAge()).isEqualTo(0);
-    assertThat(deletedCookie.getValue()).isEqualTo("");
+    Cookie deletedCookie = response.getCookie(COOKIE_NAME);
+    assertThat(deletedCookie).isNotNull()
+            .satisfies(cookie -> {
+              assertThat(cookie.getMaxAge()).isEqualTo(0);
+              assertThat(cookie.getValue()).isEqualTo("");
+            });
   }
 
   @DisplayName("성공적으로 serialize 한다.")
   @Test
-  public void serializingTest()
-      throws InvocationTargetException, InstantiationException, IllegalAccessException,
-          NoSuchMethodException {
-    // reflection
-    Constructor<?> constructor =
-        OAuth2AuthorizationRequest.Builder.class.getDeclaredConstructor(
-            AuthorizationGrantType.class);
-    constructor.setAccessible(true);
-
-    // given
-    OAuth2AuthorizationRequest.Builder builder =
-        (OAuth2AuthorizationRequest.Builder)
-            constructor.newInstance(AuthorizationGrantType.AUTHORIZATION_CODE);
-    OAuth2AuthorizationRequest request =
-        builder
-            .authorizationUri("https://kauth.kakao.com/oauth/authorize")
-            .clientId("1234")
-            .redirectUri("http://localhost/api/login/oauth2/code/kakao")
-            .scopes(Set.of("gender", "profile_image", "account_email", "profile_nickname"))
-            .state("state1934")
-            .additionalParameters(java.util.Map.of())
-            .attributes(java.util.Map.of("registration_id", "kakao"))
-            .build();
+  public void serializingTest() throws Exception {
+    OAuth2AuthorizationRequest request = createOAuth2AuthorizationRequest();
 
     // when
     String serializedRequest = CookieUtils.serialize(request);
 
     // then
-    assertTrue(Base64.isBase64(serializedRequest));
+    assertThat(serializedRequest).matches(Base64::isBase64);
   }
 
   @DisplayName("성공적으로 deserialize 한다.")
   @Test
-  public void deserializingTest()
-      throws NoSuchMethodException, InvocationTargetException, InstantiationException,
-          IllegalAccessException {
+  public void deserializingTest() throws Exception {
+    OAuth2AuthorizationRequest originalRequest = createOAuth2AuthorizationRequest();
+    String serializedRequest = CookieUtils.serialize(originalRequest);
+    Cookie cookie = new Cookie("base64", serializedRequest);
 
+    // when
+    OAuth2AuthorizationRequest deserializedRequest = CookieUtils.deserialize(cookie, OAuth2AuthorizationRequest.class);
+
+    // then
+    assertThat(deserializedRequest).usingRecursiveComparison().isEqualTo(originalRequest);
+  }
+
+  private MockHttpServletRequest createRequestWithCookie(String name, String value, int maxAge) {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    Cookie cookie = new Cookie(name, value);
+    cookie.setMaxAge(maxAge);
+    request.setCookies(cookie);
+    return request;
+  }
+
+  static private OAuth2AuthorizationRequest createOAuth2AuthorizationRequest() throws Exception {
     // reflection
-    Constructor<?> constructor =
-        OAuth2AuthorizationRequest.Builder.class.getDeclaredConstructor(
-            AuthorizationGrantType.class);
+    Constructor<?> constructor = OAuth2AuthorizationRequest.Builder.class.getDeclaredConstructor(AuthorizationGrantType.class);
     constructor.setAccessible(true);
 
-    // given
-    OAuth2AuthorizationRequest.Builder builder =
-        (OAuth2AuthorizationRequest.Builder)
-            constructor.newInstance(AuthorizationGrantType.AUTHORIZATION_CODE);
-    OAuth2AuthorizationRequest originalRequest =
-        builder
+    OAuth2AuthorizationRequest.Builder builder = (OAuth2AuthorizationRequest.Builder) constructor.newInstance(AuthorizationGrantType.AUTHORIZATION_CODE);
+    return builder
             .authorizationUri("https://kauth.kakao.com/oauth/authorize")
             .clientId("1234")
             .redirectUri("http://localhost/api/login/oauth2/code/kakao")
@@ -139,15 +124,5 @@ public class CookieUtilsTest {
             .additionalParameters(java.util.Map.of())
             .attributes(java.util.Map.of("registration_id", "kakao"))
             .build();
-
-    String serializedRequest = CookieUtils.serialize(originalRequest);
-    Cookie cookie = new Cookie("base64", serializedRequest);
-
-    // when
-    OAuth2AuthorizationRequest deserializedRequest =
-        CookieUtils.deserialize(cookie, OAuth2AuthorizationRequest.class);
-
-    // then
-    assertThat(deserializedRequest).usingRecursiveComparison().isEqualTo(originalRequest);
   }
 }

--- a/module-auth/src/test/java/com/inhabas/api/auth/domain/oauth2/cookie/CookieUtilsTest.java
+++ b/module-auth/src/test/java/com/inhabas/api/auth/domain/oauth2/cookie/CookieUtilsTest.java
@@ -1,43 +1,41 @@
 package com.inhabas.api.auth.domain.oauth2.cookie;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 import java.util.Optional;
 import java.util.Set;
 
 import javax.servlet.http.Cookie;
 
+import org.apache.commons.codec.binary.Base64;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 
-import org.apache.commons.codec.binary.Base64;
-
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
 public class CookieUtilsTest {
+
+  private static final String COOKIE_NAME = "myCookie";
+  private static final String COOKIE_CONTENTS = "hello";
+  private static final int COOKIE_MAX_AGE = 180;
 
   @DisplayName("request 에서 쿠키를 꺼낸다.")
   @Test
   public void resolveCookieFromRequest() {
     // given
-    MockHttpServletRequest request = new MockHttpServletRequest();
-    Cookie cookie = new Cookie("myCookie", "hello");
-    cookie.setMaxAge(180);
-    request.setCookies(cookie);
+    MockHttpServletRequest request = createRequestWithCookie(COOKIE_NAME, COOKIE_CONTENTS, COOKIE_MAX_AGE);
 
     // when
-    Optional<Cookie> myCookie = CookieUtils.resolveCookie(request, "myCookie");
+    Optional<Cookie> myCookie = CookieUtils.resolveCookie(request, COOKIE_NAME);
 
     // then
-    assertThat(myCookie.isPresent()).isTrue();
-    assertThat(myCookie.get().getValue()).isEqualTo("hello");
-    assertThat(myCookie.get().getMaxAge()).isEqualTo(180);
+    assertThat(myCookie).isPresent()
+            .hasValueSatisfying(cookie -> {
+              assertThat(cookie.getValue()).isEqualTo(COOKIE_CONTENTS);
+              assertThat(cookie.getMaxAge()).isEqualTo(COOKIE_MAX_AGE);
+            });
   }
 
   @DisplayName("response 에 쿠키를 저장한다.")
@@ -45,19 +43,18 @@ public class CookieUtilsTest {
   public void saveCookieToResponse() {
     // given
     MockHttpServletResponse response = new MockHttpServletResponse();
-    String cookieName = "myCookie";
-    String cookieContents = "hello";
 
     // when
-    CookieUtils.setCookie(response, cookieName, cookieContents, 180);
+    CookieUtils.setCookie(response, COOKIE_NAME, COOKIE_CONTENTS, COOKIE_MAX_AGE);
 
     // then
-    Cookie resolvedCookie = response.getCookie(cookieName);
-    assert resolvedCookie != null;
-
-    assertThat(resolvedCookie.getName()).isEqualTo(cookieName);
-    assertThat(resolvedCookie.getValue()).isEqualTo(cookieContents);
-    assertThat(resolvedCookie.getMaxAge()).isEqualTo(180);
+    Cookie resolvedCookie = response.getCookie(COOKIE_NAME);
+    assertThat(resolvedCookie).isNotNull()
+            .satisfies(cookie -> {
+              assertThat(cookie.getName()).isEqualTo(COOKIE_NAME);
+              assertThat(cookie.getValue()).isEqualTo(COOKIE_CONTENTS);
+              assertThat(cookie.getMaxAge()).isEqualTo(COOKIE_MAX_AGE);
+            });
   }
 
   @DisplayName("request 에서 쿠키를 지운다.")
@@ -65,72 +62,61 @@ public class CookieUtilsTest {
   public void removeCookieOfRequest() {
     // given
     MockHttpServletResponse response = new MockHttpServletResponse();
-    MockHttpServletRequest request = new MockHttpServletRequest();
-    Cookie cookie = new Cookie("myCookie", "hello");
-    cookie.setMaxAge(180);
-    request.setCookies(cookie);
+    MockHttpServletRequest request = createRequestWithCookie(COOKIE_NAME, COOKIE_CONTENTS, COOKIE_MAX_AGE);
 
     // when
-    CookieUtils.deleteCookie(request, response, "myCookie");
+    CookieUtils.deleteCookie(request, response, COOKIE_NAME);
 
     // then
-    Cookie deletedCookie = response.getCookie("myCookie");
-    assert deletedCookie != null;
-    assertThat(deletedCookie.getMaxAge()).isEqualTo(0);
-    assertThat(deletedCookie.getValue()).isEqualTo("");
+    Cookie deletedCookie = response.getCookie(COOKIE_NAME);
+    assertThat(deletedCookie).isNotNull()
+            .satisfies(cookie -> {
+              assertThat(cookie.getMaxAge()).isEqualTo(0);
+              assertThat(cookie.getValue()).isEqualTo("");
+            });
   }
 
   @DisplayName("성공적으로 serialize 한다.")
   @Test
-  public void serializingTest()
-      throws InvocationTargetException, InstantiationException, IllegalAccessException,
-          NoSuchMethodException {
-    // reflection
-    Constructor<?> constructor =
-        OAuth2AuthorizationRequest.Builder.class.getDeclaredConstructor(
-            AuthorizationGrantType.class);
-    constructor.setAccessible(true);
-
-    // given
-    OAuth2AuthorizationRequest.Builder builder =
-        (OAuth2AuthorizationRequest.Builder)
-            constructor.newInstance(AuthorizationGrantType.AUTHORIZATION_CODE);
-    OAuth2AuthorizationRequest request =
-        builder
-            .authorizationUri("https://kauth.kakao.com/oauth/authorize")
-            .clientId("1234")
-            .redirectUri("http://localhost/api/login/oauth2/code/kakao")
-            .scopes(Set.of("gender", "profile_image", "account_email", "profile_nickname"))
-            .state("state1934")
-            .additionalParameters(java.util.Map.of())
-            .attributes(java.util.Map.of("registration_id", "kakao"))
-            .build();
+  public void serializingTest() throws Exception {
+    OAuth2AuthorizationRequest request = createOAuth2AuthorizationRequest();
 
     // when
     String serializedRequest = CookieUtils.serialize(request);
 
     // then
-    assertTrue(Base64.isBase64(serializedRequest));
+    assertThat(serializedRequest).matches(Base64::isBase64);
   }
 
   @DisplayName("성공적으로 deserialize 한다.")
   @Test
-  public void deserializingTest()
-      throws NoSuchMethodException, InvocationTargetException, InstantiationException,
-          IllegalAccessException {
+  public void deserializingTest() throws Exception {
+    OAuth2AuthorizationRequest originalRequest = createOAuth2AuthorizationRequest();
+    String serializedRequest = CookieUtils.serialize(originalRequest);
+    Cookie cookie = new Cookie("base64", serializedRequest);
 
+    // when
+    OAuth2AuthorizationRequest deserializedRequest = CookieUtils.deserialize(cookie, OAuth2AuthorizationRequest.class);
+
+    // then
+    assertThat(deserializedRequest).usingRecursiveComparison().isEqualTo(originalRequest);
+  }
+
+  private MockHttpServletRequest createRequestWithCookie(String name, String value, int maxAge) {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    Cookie cookie = new Cookie(name, value);
+    cookie.setMaxAge(maxAge);
+    request.setCookies(cookie);
+    return request;
+  }
+
+  static private OAuth2AuthorizationRequest createOAuth2AuthorizationRequest() throws Exception {
     // reflection
-    Constructor<?> constructor =
-        OAuth2AuthorizationRequest.Builder.class.getDeclaredConstructor(
-            AuthorizationGrantType.class);
+    Constructor<?> constructor = OAuth2AuthorizationRequest.Builder.class.getDeclaredConstructor(AuthorizationGrantType.class);
     constructor.setAccessible(true);
 
-    // given
-    OAuth2AuthorizationRequest.Builder builder =
-        (OAuth2AuthorizationRequest.Builder)
-            constructor.newInstance(AuthorizationGrantType.AUTHORIZATION_CODE);
-    OAuth2AuthorizationRequest originalRequest =
-        builder
+    OAuth2AuthorizationRequest.Builder builder = (OAuth2AuthorizationRequest.Builder) constructor.newInstance(AuthorizationGrantType.AUTHORIZATION_CODE);
+    return builder
             .authorizationUri("https://kauth.kakao.com/oauth/authorize")
             .clientId("1234")
             .redirectUri("http://localhost/api/login/oauth2/code/kakao")
@@ -139,15 +125,5 @@ public class CookieUtilsTest {
             .additionalParameters(java.util.Map.of())
             .attributes(java.util.Map.of("registration_id", "kakao"))
             .build();
-
-    String serializedRequest = CookieUtils.serialize(originalRequest);
-    Cookie cookie = new Cookie("base64", serializedRequest);
-
-    // when
-    OAuth2AuthorizationRequest deserializedRequest =
-        CookieUtils.deserialize(cookie, OAuth2AuthorizationRequest.class);
-
-    // then
-    assertThat(deserializedRequest).usingRecursiveComparison().isEqualTo(originalRequest);
   }
 }


### PR DESCRIPTION
[feature/#21] 중복 코드를 제거하고, 상수를 사용함으로써 가독성을 향상시킨다.

[feature/#38] JUnit방식의 전통적인 가독성이 떨어지는 코드를 개선.

[feature/#52] JUnit방식의 전통적인 가독성이 떨어지는 코드를 개선.

[feature/#72] JUnit방식의 전통적인 가독성이 떨어지는 코드를 개선.

[feature/#85] thorws Exception으로 통합함으로써 코드 간결화

[feature/#88] 중복되는 난잡한 코드를 함수로 처리

[feature/#113] AsstertJ의 함술로 수정

[feature/#106] 반복되는 cookie 설정 함수 추가

[feature/#114]

- OAuth2AuthorizationRequest.Builder를 사용하여 OAuth2AuthorizationRequest 객체를 생성하는 로직을 createOAuth2AuthorizationRequest 함수로 분리
- 중복 제거 및 가독성 개선