### PR TITLE
Feature/refactoring

### DIFF
--- a/module-auth/src/test/java/com/inhabas/api/auth/domain/oauth2/cookie/CookieUtilsTest.java
+++ b/module-auth/src/test/java/com/inhabas/api/auth/domain/oauth2/cookie/CookieUtilsTest.java
@@ -1,40 +1,43 @@
 package com.inhabas.api.auth.domain.oauth2.cookie;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Optional;
 import java.util.Set;
 
 import javax.servlet.http.Cookie;
 
-import org.apache.commons.codec.binary.Base64;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 
-public class CookieUtilsTest {
+import org.apache.commons.codec.binary.Base64;
 
-  private static final String COOKIE_NAME = "myCookie";
-  private static final String COOKIE_CONTENTS = "hello";
-  private static final int COOKIE_MAX_AGE = 180;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class CookieUtilsTest {
 
   @DisplayName("request 에서 쿠키를 꺼낸다.")
   @Test
   public void resolveCookieFromRequest() {
     // given
-    MockHttpServletRequest request = createRequestWithCookie(COOKIE_NAME, COOKIE_CONTENTS, COOKIE_MAX_AGE);
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    Cookie cookie = new Cookie("myCookie", "hello");
+    cookie.setMaxAge(180);
+    request.setCookies(cookie);
 
     // when
-    Optional<Cookie> myCookie = CookieUtils.resolveCookie(request, COOKIE_NAME);
+    Optional<Cookie> myCookie = CookieUtils.resolveCookie(request, "myCookie");
 
     // then
-    assertThat(myCookie).isPresent()
-            .hasValueSatisfying(cookie -> {
-              assertThat(cookie.getValue()).isEqualTo(COOKIE_CONTENTS);
-              assertThat(cookie.getMaxAge()).isEqualTo(COOKIE_MAX_AGE);
-            });
+    assertThat(myCookie.isPresent()).isTrue();
+    assertThat(myCookie.get().getValue()).isEqualTo("hello");
+    assertThat(myCookie.get().getMaxAge()).isEqualTo(180);
   }
 
   @DisplayName("response 에 쿠키를 저장한다.")
@@ -42,18 +45,19 @@ public class CookieUtilsTest {
   public void saveCookieToResponse() {
     // given
     MockHttpServletResponse response = new MockHttpServletResponse();
+    String cookieName = "myCookie";
+    String cookieContents = "hello";
 
     // when
-    CookieUtils.setCookie(response, COOKIE_NAME, COOKIE_CONTENTS, COOKIE_MAX_AGE);
+    CookieUtils.setCookie(response, cookieName, cookieContents, 180);
 
     // then
-    Cookie resolvedCookie = response.getCookie(COOKIE_NAME);
-    assertThat(resolvedCookie).isNotNull()
-            .satisfies(cookie -> {
-              assertThat(cookie.getName()).isEqualTo(COOKIE_NAME);
-              assertThat(cookie.getValue()).isEqualTo(COOKIE_CONTENTS);
-              assertThat(cookie.getMaxAge()).isEqualTo(COOKIE_MAX_AGE);
-            });
+    Cookie resolvedCookie = response.getCookie(cookieName);
+    assert resolvedCookie != null;
+
+    assertThat(resolvedCookie.getName()).isEqualTo(cookieName);
+    assertThat(resolvedCookie.getValue()).isEqualTo(cookieContents);
+    assertThat(resolvedCookie.getMaxAge()).isEqualTo(180);
   }
 
   @DisplayName("request 에서 쿠키를 지운다.")
@@ -61,61 +65,38 @@ public class CookieUtilsTest {
   public void removeCookieOfRequest() {
     // given
     MockHttpServletResponse response = new MockHttpServletResponse();
-    MockHttpServletRequest request = createRequestWithCookie(COOKIE_NAME, COOKIE_CONTENTS, COOKIE_MAX_AGE);
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    Cookie cookie = new Cookie("myCookie", "hello");
+    cookie.setMaxAge(180);
+    request.setCookies(cookie);
 
     // when
-    CookieUtils.deleteCookie(request, response, COOKIE_NAME);
+    CookieUtils.deleteCookie(request, response, "myCookie");
 
     // then
-    Cookie deletedCookie = response.getCookie(COOKIE_NAME);
-    assertThat(deletedCookie).isNotNull()
-            .satisfies(cookie -> {
-              assertThat(cookie.getMaxAge()).isEqualTo(0);
-              assertThat(cookie.getValue()).isEqualTo("");
-            });
+    Cookie deletedCookie = response.getCookie("myCookie");
+    assert deletedCookie != null;
+    assertThat(deletedCookie.getMaxAge()).isEqualTo(0);
+    assertThat(deletedCookie.getValue()).isEqualTo("");
   }
 
   @DisplayName("성공적으로 serialize 한다.")
   @Test
-  public void serializingTest() throws Exception {
-    OAuth2AuthorizationRequest request = createOAuth2AuthorizationRequest();
-
-    // when
-    String serializedRequest = CookieUtils.serialize(request);
-
-    // then
-    assertThat(serializedRequest).matches(Base64::isBase64);
-  }
-
-  @DisplayName("성공적으로 deserialize 한다.")
-  @Test
-  public void deserializingTest() throws Exception {
-    OAuth2AuthorizationRequest originalRequest = createOAuth2AuthorizationRequest();
-    String serializedRequest = CookieUtils.serialize(originalRequest);
-    Cookie cookie = new Cookie("base64", serializedRequest);
-
-    // when
-    OAuth2AuthorizationRequest deserializedRequest = CookieUtils.deserialize(cookie, OAuth2AuthorizationRequest.class);
-
-    // then
-    assertThat(deserializedRequest).usingRecursiveComparison().isEqualTo(originalRequest);
-  }
-
-  private MockHttpServletRequest createRequestWithCookie(String name, String value, int maxAge) {
-    MockHttpServletRequest request = new MockHttpServletRequest();
-    Cookie cookie = new Cookie(name, value);
-    cookie.setMaxAge(maxAge);
-    request.setCookies(cookie);
-    return request;
-  }
-
-  static private OAuth2AuthorizationRequest createOAuth2AuthorizationRequest() throws Exception {
+  public void serializingTest()
+      throws InvocationTargetException, InstantiationException, IllegalAccessException,
+          NoSuchMethodException {
     // reflection
-    Constructor<?> constructor = OAuth2AuthorizationRequest.Builder.class.getDeclaredConstructor(AuthorizationGrantType.class);
+    Constructor<?> constructor =
+        OAuth2AuthorizationRequest.Builder.class.getDeclaredConstructor(
+            AuthorizationGrantType.class);
     constructor.setAccessible(true);
 
-    OAuth2AuthorizationRequest.Builder builder = (OAuth2AuthorizationRequest.Builder) constructor.newInstance(AuthorizationGrantType.AUTHORIZATION_CODE);
-    return builder
+    // given
+    OAuth2AuthorizationRequest.Builder builder =
+        (OAuth2AuthorizationRequest.Builder)
+            constructor.newInstance(AuthorizationGrantType.AUTHORIZATION_CODE);
+    OAuth2AuthorizationRequest request =
+        builder
             .authorizationUri("https://kauth.kakao.com/oauth/authorize")
             .clientId("1234")
             .redirectUri("http://localhost/api/login/oauth2/code/kakao")
@@ -124,5 +105,49 @@ public class CookieUtilsTest {
             .additionalParameters(java.util.Map.of())
             .attributes(java.util.Map.of("registration_id", "kakao"))
             .build();
+
+    // when
+    String serializedRequest = CookieUtils.serialize(request);
+
+    // then
+    assertTrue(Base64.isBase64(serializedRequest));
+  }
+
+  @DisplayName("성공적으로 deserialize 한다.")
+  @Test
+  public void deserializingTest()
+      throws NoSuchMethodException, InvocationTargetException, InstantiationException,
+          IllegalAccessException {
+
+    // reflection
+    Constructor<?> constructor =
+        OAuth2AuthorizationRequest.Builder.class.getDeclaredConstructor(
+            AuthorizationGrantType.class);
+    constructor.setAccessible(true);
+
+    // given
+    OAuth2AuthorizationRequest.Builder builder =
+        (OAuth2AuthorizationRequest.Builder)
+            constructor.newInstance(AuthorizationGrantType.AUTHORIZATION_CODE);
+    OAuth2AuthorizationRequest originalRequest =
+        builder
+            .authorizationUri("https://kauth.kakao.com/oauth/authorize")
+            .clientId("1234")
+            .redirectUri("http://localhost/api/login/oauth2/code/kakao")
+            .scopes(Set.of("gender", "profile_image", "account_email", "profile_nickname"))
+            .state("state1934")
+            .additionalParameters(java.util.Map.of())
+            .attributes(java.util.Map.of("registration_id", "kakao"))
+            .build();
+
+    String serializedRequest = CookieUtils.serialize(originalRequest);
+    Cookie cookie = new Cookie("base64", serializedRequest);
+
+    // when
+    OAuth2AuthorizationRequest deserializedRequest =
+        CookieUtils.deserialize(cookie, OAuth2AuthorizationRequest.class);
+
+    // then
+    assertThat(deserializedRequest).usingRecursiveComparison().isEqualTo(originalRequest);
   }
 }

--- a/module-auth/src/test/java/com/inhabas/api/auth/domain/oauth2/cookie/CookieUtilsTest.java
+++ b/module-auth/src/test/java/com/inhabas/api/auth/domain/oauth2/cookie/CookieUtilsTest.java
@@ -1,43 +1,40 @@
 package com.inhabas.api.auth.domain.oauth2.cookie;
-
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 import java.util.Optional;
 import java.util.Set;
 
 import javax.servlet.http.Cookie;
 
+import org.apache.commons.codec.binary.Base64;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 
-import org.apache.commons.codec.binary.Base64;
-
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
 public class CookieUtilsTest {
+
+  private static final String COOKIE_NAME = "myCookie";
+  private static final String COOKIE_CONTENTS = "hello";
+  private static final int COOKIE_MAX_AGE = 180;
 
   @DisplayName("request 에서 쿠키를 꺼낸다.")
   @Test
   public void resolveCookieFromRequest() {
     // given
-    MockHttpServletRequest request = new MockHttpServletRequest();
-    Cookie cookie = new Cookie("myCookie", "hello");
-    cookie.setMaxAge(180);
-    request.setCookies(cookie);
+    MockHttpServletRequest request = createRequestWithCookie(COOKIE_NAME, COOKIE_CONTENTS, COOKIE_MAX_AGE);
 
     // when
-    Optional<Cookie> myCookie = CookieUtils.resolveCookie(request, "myCookie");
+    Optional<Cookie> myCookie = CookieUtils.resolveCookie(request, COOKIE_NAME);
 
     // then
-    assertThat(myCookie.isPresent()).isTrue();
-    assertThat(myCookie.get().getValue()).isEqualTo("hello");
-    assertThat(myCookie.get().getMaxAge()).isEqualTo(180);
+    assertThat(myCookie).isPresent()
+            .hasValueSatisfying(cookie -> {
+              assertThat(cookie.getValue()).isEqualTo(COOKIE_CONTENTS);
+              assertThat(cookie.getMaxAge()).isEqualTo(COOKIE_MAX_AGE);
+            });
   }
 
   @DisplayName("response 에 쿠키를 저장한다.")
@@ -45,19 +42,18 @@ public class CookieUtilsTest {
   public void saveCookieToResponse() {
     // given
     MockHttpServletResponse response = new MockHttpServletResponse();
-    String cookieName = "myCookie";
-    String cookieContents = "hello";
 
     // when
-    CookieUtils.setCookie(response, cookieName, cookieContents, 180);
+    CookieUtils.setCookie(response, COOKIE_NAME, COOKIE_CONTENTS, COOKIE_MAX_AGE);
 
     // then
-    Cookie resolvedCookie = response.getCookie(cookieName);
-    assert resolvedCookie != null;
-
-    assertThat(resolvedCookie.getName()).isEqualTo(cookieName);
-    assertThat(resolvedCookie.getValue()).isEqualTo(cookieContents);
-    assertThat(resolvedCookie.getMaxAge()).isEqualTo(180);
+    Cookie resolvedCookie = response.getCookie(COOKIE_NAME);
+    assertThat(resolvedCookie).isNotNull()
+            .satisfies(cookie -> {
+              assertThat(cookie.getName()).isEqualTo(COOKIE_NAME);
+              assertThat(cookie.getValue()).isEqualTo(COOKIE_CONTENTS);
+              assertThat(cookie.getMaxAge()).isEqualTo(COOKIE_MAX_AGE);
+            });
   }
 
   @DisplayName("request 에서 쿠키를 지운다.")
@@ -65,72 +61,61 @@ public class CookieUtilsTest {
   public void removeCookieOfRequest() {
     // given
     MockHttpServletResponse response = new MockHttpServletResponse();
-    MockHttpServletRequest request = new MockHttpServletRequest();
-    Cookie cookie = new Cookie("myCookie", "hello");
-    cookie.setMaxAge(180);
-    request.setCookies(cookie);
+    MockHttpServletRequest request = createRequestWithCookie(COOKIE_NAME, COOKIE_CONTENTS, COOKIE_MAX_AGE);
 
     // when
-    CookieUtils.deleteCookie(request, response, "myCookie");
+    CookieUtils.deleteCookie(request, response, COOKIE_NAME);
 
     // then
-    Cookie deletedCookie = response.getCookie("myCookie");
-    assert deletedCookie != null;
-    assertThat(deletedCookie.getMaxAge()).isEqualTo(0);
-    assertThat(deletedCookie.getValue()).isEqualTo("");
+    Cookie deletedCookie = response.getCookie(COOKIE_NAME);
+    assertThat(deletedCookie).isNotNull()
+            .satisfies(cookie -> {
+              assertThat(cookie.getMaxAge()).isEqualTo(0);
+              assertThat(cookie.getValue()).isEqualTo("");
+            });
   }
 
   @DisplayName("성공적으로 serialize 한다.")
   @Test
-  public void serializingTest()
-      throws InvocationTargetException, InstantiationException, IllegalAccessException,
-          NoSuchMethodException {
-    // reflection
-    Constructor<?> constructor =
-        OAuth2AuthorizationRequest.Builder.class.getDeclaredConstructor(
-            AuthorizationGrantType.class);
-    constructor.setAccessible(true);
-
-    // given
-    OAuth2AuthorizationRequest.Builder builder =
-        (OAuth2AuthorizationRequest.Builder)
-            constructor.newInstance(AuthorizationGrantType.AUTHORIZATION_CODE);
-    OAuth2AuthorizationRequest request =
-        builder
-            .authorizationUri("https://kauth.kakao.com/oauth/authorize")
-            .clientId("1234")
-            .redirectUri("http://localhost/api/login/oauth2/code/kakao")
-            .scopes(Set.of("gender", "profile_image", "account_email", "profile_nickname"))
-            .state("state1934")
-            .additionalParameters(java.util.Map.of())
-            .attributes(java.util.Map.of("registration_id", "kakao"))
-            .build();
+  public void serializingTest() throws Exception {
+    OAuth2AuthorizationRequest request = createOAuth2AuthorizationRequest();
 
     // when
     String serializedRequest = CookieUtils.serialize(request);
 
     // then
-    assertTrue(Base64.isBase64(serializedRequest));
+    assertThat(serializedRequest).matches(Base64::isBase64);
   }
 
   @DisplayName("성공적으로 deserialize 한다.")
   @Test
-  public void deserializingTest()
-      throws NoSuchMethodException, InvocationTargetException, InstantiationException,
-          IllegalAccessException {
+  public void deserializingTest() throws Exception {
+    OAuth2AuthorizationRequest originalRequest = createOAuth2AuthorizationRequest();
+    String serializedRequest = CookieUtils.serialize(originalRequest);
+    Cookie cookie = new Cookie("base64", serializedRequest);
 
+    // when
+    OAuth2AuthorizationRequest deserializedRequest = CookieUtils.deserialize(cookie, OAuth2AuthorizationRequest.class);
+
+    // then
+    assertThat(deserializedRequest).usingRecursiveComparison().isEqualTo(originalRequest);
+  }
+
+  private MockHttpServletRequest createRequestWithCookie(String name, String value, int maxAge) {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    Cookie cookie = new Cookie(name, value);
+    cookie.setMaxAge(maxAge);
+    request.setCookies(cookie);
+    return request;
+  }
+
+  static private OAuth2AuthorizationRequest createOAuth2AuthorizationRequest() throws Exception {
     // reflection
-    Constructor<?> constructor =
-        OAuth2AuthorizationRequest.Builder.class.getDeclaredConstructor(
-            AuthorizationGrantType.class);
+    Constructor<?> constructor = OAuth2AuthorizationRequest.Builder.class.getDeclaredConstructor(AuthorizationGrantType.class);
     constructor.setAccessible(true);
 
-    // given
-    OAuth2AuthorizationRequest.Builder builder =
-        (OAuth2AuthorizationRequest.Builder)
-            constructor.newInstance(AuthorizationGrantType.AUTHORIZATION_CODE);
-    OAuth2AuthorizationRequest originalRequest =
-        builder
+    OAuth2AuthorizationRequest.Builder builder = (OAuth2AuthorizationRequest.Builder) constructor.newInstance(AuthorizationGrantType.AUTHORIZATION_CODE);
+    return builder
             .authorizationUri("https://kauth.kakao.com/oauth/authorize")
             .clientId("1234")
             .redirectUri("http://localhost/api/login/oauth2/code/kakao")
@@ -139,15 +124,5 @@ public class CookieUtilsTest {
             .additionalParameters(java.util.Map.of())
             .attributes(java.util.Map.of("registration_id", "kakao"))
             .build();
-
-    String serializedRequest = CookieUtils.serialize(originalRequest);
-    Cookie cookie = new Cookie("base64", serializedRequest);
-
-    // when
-    OAuth2AuthorizationRequest deserializedRequest =
-        CookieUtils.deserialize(cookie, OAuth2AuthorizationRequest.class);
-
-    // then
-    assertThat(deserializedRequest).usingRecursiveComparison().isEqualTo(originalRequest);
   }
 }

--- a/module-auth/src/test/java/com/inhabas/api/auth/domain/oauth2/cookie/CookieUtilsTest.java
+++ b/module-auth/src/test/java/com/inhabas/api/auth/domain/oauth2/cookie/CookieUtilsTest.java
@@ -1,7 +1,6 @@
 package com.inhabas.api.auth.domain.oauth2.cookie;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -22,22 +21,28 @@ import org.junit.jupiter.api.Test;
 
 public class CookieUtilsTest {
 
+  private static final String COOKIE_NAME = "myCookie";
+  private static final String COOKIE_CONTENTS = "hello";
+  private static final int COOKIE_MAX_AGE = 180;
+
   @DisplayName("request 에서 쿠키를 꺼낸다.")
   @Test
   public void resolveCookieFromRequest() {
     // given
-    MockHttpServletRequest request = new MockHttpServletRequest();
-    Cookie cookie = new Cookie("myCookie", "hello");
-    cookie.setMaxAge(180);
-    request.setCookies(cookie);
+    MockHttpServletRequest request =
+        createRequestWithCookie(COOKIE_NAME, COOKIE_CONTENTS, COOKIE_MAX_AGE);
 
     // when
-    Optional<Cookie> myCookie = CookieUtils.resolveCookie(request, "myCookie");
+    Optional<Cookie> myCookie = CookieUtils.resolveCookie(request, COOKIE_NAME);
 
     // then
-    assertThat(myCookie.isPresent()).isTrue();
-    assertThat(myCookie.get().getValue()).isEqualTo("hello");
-    assertThat(myCookie.get().getMaxAge()).isEqualTo(180);
+    assertThat(myCookie)
+        .isPresent()
+        .hasValueSatisfying(
+            cookie -> {
+              assertThat(cookie.getValue()).isEqualTo(COOKIE_CONTENTS);
+              assertThat(cookie.getMaxAge()).isEqualTo(COOKIE_MAX_AGE);
+            });
   }
 
   @DisplayName("response 에 쿠키를 저장한다.")
@@ -45,19 +50,20 @@ public class CookieUtilsTest {
   public void saveCookieToResponse() {
     // given
     MockHttpServletResponse response = new MockHttpServletResponse();
-    String cookieName = "myCookie";
-    String cookieContents = "hello";
 
     // when
-    CookieUtils.setCookie(response, cookieName, cookieContents, 180);
+    CookieUtils.setCookie(response, COOKIE_NAME, COOKIE_CONTENTS, COOKIE_MAX_AGE);
 
     // then
-    Cookie resolvedCookie = response.getCookie(cookieName);
-    assert resolvedCookie != null;
-
-    assertThat(resolvedCookie.getName()).isEqualTo(cookieName);
-    assertThat(resolvedCookie.getValue()).isEqualTo(cookieContents);
-    assertThat(resolvedCookie.getMaxAge()).isEqualTo(180);
+    Cookie resolvedCookie = response.getCookie(COOKIE_NAME);
+    assertThat(resolvedCookie)
+        .isNotNull()
+        .satisfies(
+            cookie -> {
+              assertThat(cookie.getName()).isEqualTo(COOKIE_NAME);
+              assertThat(cookie.getValue()).isEqualTo(COOKIE_CONTENTS);
+              assertThat(cookie.getMaxAge()).isEqualTo(COOKIE_MAX_AGE);
+            });
   }
 
   @DisplayName("request 에서 쿠키를 지운다.")
@@ -65,52 +71,35 @@ public class CookieUtilsTest {
   public void removeCookieOfRequest() {
     // given
     MockHttpServletResponse response = new MockHttpServletResponse();
-    MockHttpServletRequest request = new MockHttpServletRequest();
-    Cookie cookie = new Cookie("myCookie", "hello");
-    cookie.setMaxAge(180);
-    request.setCookies(cookie);
+    MockHttpServletRequest request =
+        createRequestWithCookie(COOKIE_NAME, COOKIE_CONTENTS, COOKIE_MAX_AGE);
 
     // when
-    CookieUtils.deleteCookie(request, response, "myCookie");
+    CookieUtils.deleteCookie(request, response, COOKIE_NAME);
 
     // then
-    Cookie deletedCookie = response.getCookie("myCookie");
-    assert deletedCookie != null;
-    assertThat(deletedCookie.getMaxAge()).isEqualTo(0);
-    assertThat(deletedCookie.getValue()).isEqualTo("");
+    Cookie deletedCookie = response.getCookie(COOKIE_NAME);
+    assertThat(deletedCookie)
+        .isNotNull()
+        .satisfies(
+            cookie -> {
+              assertThat(cookie.getMaxAge()).isEqualTo(0);
+              assertThat(cookie.getValue()).isEmpty();
+            });
   }
 
   @DisplayName("성공적으로 serialize 한다.")
   @Test
   public void serializingTest()
-      throws InvocationTargetException, InstantiationException, IllegalAccessException,
-          NoSuchMethodException {
-    // reflection
-    Constructor<?> constructor =
-        OAuth2AuthorizationRequest.Builder.class.getDeclaredConstructor(
-            AuthorizationGrantType.class);
-    constructor.setAccessible(true);
-
-    // given
-    OAuth2AuthorizationRequest.Builder builder =
-        (OAuth2AuthorizationRequest.Builder)
-            constructor.newInstance(AuthorizationGrantType.AUTHORIZATION_CODE);
-    OAuth2AuthorizationRequest request =
-        builder
-            .authorizationUri("https://kauth.kakao.com/oauth/authorize")
-            .clientId("1234")
-            .redirectUri("http://localhost/api/login/oauth2/code/kakao")
-            .scopes(Set.of("gender", "profile_image", "account_email", "profile_nickname"))
-            .state("state1934")
-            .additionalParameters(java.util.Map.of())
-            .attributes(java.util.Map.of("registration_id", "kakao"))
-            .build();
+      throws NoSuchMethodException, InvocationTargetException, InstantiationException,
+          IllegalAccessException {
+    OAuth2AuthorizationRequest request = createOAuth2AuthorizationRequest();
 
     // when
     String serializedRequest = CookieUtils.serialize(request);
 
     // then
-    assertTrue(Base64.isBase64(serializedRequest));
+    assertThat(serializedRequest).matches(Base64::isBase64);
   }
 
   @DisplayName("성공적으로 deserialize 한다.")
@@ -118,28 +107,7 @@ public class CookieUtilsTest {
   public void deserializingTest()
       throws NoSuchMethodException, InvocationTargetException, InstantiationException,
           IllegalAccessException {
-
-    // reflection
-    Constructor<?> constructor =
-        OAuth2AuthorizationRequest.Builder.class.getDeclaredConstructor(
-            AuthorizationGrantType.class);
-    constructor.setAccessible(true);
-
-    // given
-    OAuth2AuthorizationRequest.Builder builder =
-        (OAuth2AuthorizationRequest.Builder)
-            constructor.newInstance(AuthorizationGrantType.AUTHORIZATION_CODE);
-    OAuth2AuthorizationRequest originalRequest =
-        builder
-            .authorizationUri("https://kauth.kakao.com/oauth/authorize")
-            .clientId("1234")
-            .redirectUri("http://localhost/api/login/oauth2/code/kakao")
-            .scopes(Set.of("gender", "profile_image", "account_email", "profile_nickname"))
-            .state("state1934")
-            .additionalParameters(java.util.Map.of())
-            .attributes(java.util.Map.of("registration_id", "kakao"))
-            .build();
-
+    OAuth2AuthorizationRequest originalRequest = createOAuth2AuthorizationRequest();
     String serializedRequest = CookieUtils.serialize(originalRequest);
     Cookie cookie = new Cookie("base64", serializedRequest);
 
@@ -149,5 +117,36 @@ public class CookieUtilsTest {
 
     // then
     assertThat(deserializedRequest).usingRecursiveComparison().isEqualTo(originalRequest);
+  }
+
+  private MockHttpServletRequest createRequestWithCookie(String name, String value, int maxAge) {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    Cookie cookie = new Cookie(name, value);
+    cookie.setMaxAge(maxAge);
+    request.setCookies(cookie);
+    return request;
+  }
+
+  private static OAuth2AuthorizationRequest createOAuth2AuthorizationRequest()
+      throws NoSuchMethodException, InvocationTargetException, InstantiationException,
+          IllegalAccessException {
+    // reflection
+    Constructor<?> constructor =
+        OAuth2AuthorizationRequest.Builder.class.getDeclaredConstructor(
+            AuthorizationGrantType.class);
+    constructor.setAccessible(true);
+
+    OAuth2AuthorizationRequest.Builder builder =
+        (OAuth2AuthorizationRequest.Builder)
+            constructor.newInstance(AuthorizationGrantType.AUTHORIZATION_CODE);
+    return builder
+        .authorizationUri("https://kauth.kakao.com/oauth/authorize")
+        .clientId("1234")
+        .redirectUri("http://localhost/api/login/oauth2/code/kakao")
+        .scopes(Set.of("gender", "profile_image", "account_email", "profile_nickname"))
+        .state("state1934")
+        .additionalParameters(java.util.Map.of())
+        .attributes(java.util.Map.of("registration_id", "kakao"))
+        .build();
   }
 }

--- a/module-auth/src/test/java/com/inhabas/api/auth/domain/oauth2/cookie/HttpCookieOAuth2AuthorizationRequestRepositoryTest.java
+++ b/module-auth/src/test/java/com/inhabas/api/auth/domain/oauth2/cookie/HttpCookieOAuth2AuthorizationRequestRepositoryTest.java
@@ -3,7 +3,6 @@ package com.inhabas.api.auth.domain.oauth2.cookie;
 import static com.inhabas.api.auth.domain.oauth2.cookie.HttpCookieOAuth2AuthorizationRequestRepository.OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME;
 import static com.inhabas.api.auth.domain.oauth2.cookie.HttpCookieOAuth2AuthorizationRequestRepository.REDIRECT_URL_PARAM_COOKIE_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -19,10 +18,18 @@ import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequ
 
 import org.apache.commons.codec.binary.Base64;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 public class HttpCookieOAuth2AuthorizationRequestRepositoryTest {
+
+  private HttpCookieOAuth2AuthorizationRequestRepository repository;
+
+  @BeforeEach
+  public void setUp() {
+    repository = new HttpCookieOAuth2AuthorizationRequestRepository();
+  }
 
   private final HttpCookieOAuth2AuthorizationRequestRepository
       httpCookieOAuth2AuthorizationRequestRepository =
@@ -62,8 +69,7 @@ public class HttpCookieOAuth2AuthorizationRequestRepositoryTest {
     MockHttpServletResponse response = new MockHttpServletResponse();
 
     // when
-    httpCookieOAuth2AuthorizationRequestRepository.saveAuthorizationRequest(
-        null, request, response);
+    repository.saveAuthorizationRequest(null, request, response);
 
     // then
     assertThat(response.getCookies())
@@ -83,14 +89,13 @@ public class HttpCookieOAuth2AuthorizationRequestRepositoryTest {
     OAuth2AuthorizationRequest oAuth2AuthorizationRequest = this.createOAuth2AuthorizationRequest();
 
     // when
-    httpCookieOAuth2AuthorizationRequestRepository.saveAuthorizationRequest(
-        oAuth2AuthorizationRequest, request, response);
+    repository.saveAuthorizationRequest(oAuth2AuthorizationRequest, request, response);
 
     // then
     // 쿠키 한가지 존재하는지 확인.
     Cookie savedCookie = response.getCookie(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
-    assert savedCookie != null;
-    assertTrue(Base64.isBase64(savedCookie.getValue()));
+    assertThat(savedCookie).isNotNull();
+    assertThat(Base64.isBase64(savedCookie.getValue())).isTrue();
   }
 
   @DisplayName("OAuth2AuthorizationRequest 를 쿠키로 저장할 때, redirect_url 도 쿠키로 저장한다.")
@@ -104,8 +109,7 @@ public class HttpCookieOAuth2AuthorizationRequestRepositoryTest {
     request.setParameter(REDIRECT_URL_PARAM_COOKIE_NAME, "/index.html");
 
     // when
-    httpCookieOAuth2AuthorizationRequestRepository.saveAuthorizationRequest(
-        oAuth2AuthorizationRequest, request, response);
+    repository.saveAuthorizationRequest(oAuth2AuthorizationRequest, request, response);
 
     // then
     // 쿠키 두가지 존재하는 지 확인
@@ -133,13 +137,13 @@ public class HttpCookieOAuth2AuthorizationRequestRepositoryTest {
 
     // when
     OAuth2AuthorizationRequest returnedRequest =
-        httpCookieOAuth2AuthorizationRequestRepository.removeAuthorizationRequest(
-            request, response);
+        repository.removeAuthorizationRequest(request, response);
 
     // then
     Cookie cookie = response.getCookie(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
-    assert cookie != null;
-    assertTrue(cookie.getValue().isBlank() && cookie.getMaxAge() == 0);
+    assertThat(cookie).isNotNull();
+    assertThat(cookie.getValue()).isBlank();
+    assertThat(cookie.getMaxAge()).isEqualTo(0);
   }
 
   @DisplayName("OAuth2AuthorizationRequest 를 성공적으로 쿠키에서 삭제한다. (redirectUrl 쿠키도 삭제된다.)")
@@ -150,7 +154,7 @@ public class HttpCookieOAuth2AuthorizationRequestRepositoryTest {
     MockHttpServletResponse response = new MockHttpServletResponse();
 
     // when
-    httpCookieOAuth2AuthorizationRequestRepository.clearCookies(request, response);
+    repository.clearCookies(request, response);
 
     // then
     assertThat(response.getCookies())
@@ -189,8 +193,8 @@ public class HttpCookieOAuth2AuthorizationRequestRepositoryTest {
           .attributes(java.util.Map.of("registration_id", "kakao"))
           .build();
 
-    } catch (InvocationTargetException | InstantiationException | IllegalAccessException ignored) {
-      return null;
+    } catch (InvocationTargetException | InstantiationException | IllegalAccessException e) {
+      throw new RuntimeException("Failed to create OAuth2AuthorizationRequest", e);
     }
   }
 }

--- a/module-auth/src/test/java/com/inhabas/api/auth/domain/oauth2/handler/Oauth2AuthenticationFailureHandlerTest.java
+++ b/module-auth/src/test/java/com/inhabas/api/auth/domain/oauth2/handler/Oauth2AuthenticationFailureHandlerTest.java
@@ -38,53 +38,62 @@ public class Oauth2AuthenticationFailureHandlerTest {
 
   @Mock private AuthProperties.OAuth2 oauth2Utils;
 
+
+  private static final String VALID_REDIRECT_URL = "https://www.inhabas.com";
+  private static final String INVALID_REDIRECT_URL = "https://www.unauthorized_url.com";
+  private static final String ERROR_CODE = OAuth2ErrorCodes.INVALID_REQUEST;
+
   @BeforeEach
   public void setUp() {
     given(authProperties.getOauth2()).willReturn(oauth2Utils);
   }
 
+  private MockHttpServletRequest createRequestWithCookie(String cookieValue) {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    Cookie redirectCookie = new Cookie(REDIRECT_URL_PARAM_COOKIE_NAME, cookieValue);
+    request.setCookies(redirectCookie);
+    return request;
+  }
+
+  private AuthenticationException createAuthenticationException(String errorCode) {
+    return new OAuth2AuthenticationException(errorCode);
+  }
+
+
   @DisplayName("FailureHandler 호출 시, 허락된 defaultURL 로 정상적으로 리다이렉트 된다.")
   @Test
   public void redirectToDefaultTest() throws IOException {
     // given
-    String errorCode = OAuth2ErrorCodes.INVALID_REQUEST;
-    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletRequest request = createRequestWithCookie(VALID_REDIRECT_URL);
     MockHttpServletResponse response = new MockHttpServletResponse();
-    AuthenticationException authenticationException = new OAuth2AuthenticationException(errorCode);
+    AuthenticationException authenticationException = new OAuth2AuthenticationException(ERROR_CODE);
 
-    Cookie redirectCookie = new Cookie(REDIRECT_URL_PARAM_COOKIE_NAME, "https://www.inhabas.com");
-    request.setCookies(redirectCookie);
-
-    given(oauth2Utils.getDefaultRedirectUri()).willReturn("https://www.inhabas.com");
+    given(oauth2Utils.getDefaultRedirectUri()).willReturn(VALID_REDIRECT_URL);
 
     // when
     oauth2AuthenticationFailureHandler.onAuthenticationFailure(
         request, response, authenticationException);
 
     // then
-    assertThat(response.getRedirectedUrl()).isEqualTo("https://www.inhabas.com?error=" + errorCode);
+    assertThat(response.getRedirectedUrl()).isEqualTo(VALID_REDIRECT_URL + "?error=" + ERROR_CODE);
+
   }
 
   @DisplayName("유효하지 않은 redirect_url 은 허용하지 않는다.")
   @Test
   public void validateRedirectUrlTest() throws IOException {
     // given
-    String errorCode = OAuth2ErrorCodes.INVALID_REQUEST;
-    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletRequest request = createRequestWithCookie(INVALID_REDIRECT_URL);
     MockHttpServletResponse response = new MockHttpServletResponse();
-    AuthenticationException authenticationException = new OAuth2AuthenticationException(errorCode);
+    AuthenticationException authenticationException = createAuthenticationException(ERROR_CODE);
 
-    Cookie redirectCookie =
-        new Cookie(REDIRECT_URL_PARAM_COOKIE_NAME, "https://www.unauthorized_url.com");
-    request.setCookies(redirectCookie);
-
-    given(oauth2Utils.getDefaultRedirectUri()).willReturn("https://www.inhabas.com");
+    given(oauth2Utils.getDefaultRedirectUri()).willReturn(VALID_REDIRECT_URL);
 
     // when
     oauth2AuthenticationFailureHandler.onAuthenticationFailure(
         request, response, authenticationException);
 
     // then
-    assertThat(response.getRedirectedUrl()).isEqualTo("https://www.inhabas.com?error=" + errorCode);
+    assertThat(response.getRedirectedUrl()).isEqualTo(VALID_REDIRECT_URL + "?error=" + ERROR_CODE);
   }
 }

--- a/module-auth/src/test/java/com/inhabas/api/auth/domain/oauth2/handler/Oauth2AuthenticationFailureHandlerTest.java
+++ b/module-auth/src/test/java/com/inhabas/api/auth/domain/oauth2/handler/Oauth2AuthenticationFailureHandlerTest.java
@@ -38,7 +38,6 @@ public class Oauth2AuthenticationFailureHandlerTest {
 
   @Mock private AuthProperties.OAuth2 oauth2Utils;
 
-
   private static final String VALID_REDIRECT_URL = "https://www.inhabas.com";
   private static final String INVALID_REDIRECT_URL = "https://www.unauthorized_url.com";
   private static final String ERROR_CODE = OAuth2ErrorCodes.INVALID_REQUEST;
@@ -59,7 +58,6 @@ public class Oauth2AuthenticationFailureHandlerTest {
     return new OAuth2AuthenticationException(errorCode);
   }
 
-
   @DisplayName("FailureHandler 호출 시, 허락된 defaultURL 로 정상적으로 리다이렉트 된다.")
   @Test
   public void redirectToDefaultTest() throws IOException {
@@ -76,7 +74,6 @@ public class Oauth2AuthenticationFailureHandlerTest {
 
     // then
     assertThat(response.getRedirectedUrl()).isEqualTo(VALID_REDIRECT_URL + "?error=" + ERROR_CODE);
-
   }
 
   @DisplayName("유효하지 않은 redirect_url 은 허용하지 않는다.")

--- a/module-auth/src/test/java/com/inhabas/api/auth/domain/oauth2/handler/Oauth2AuthenticationSuccessHandlerTest.java
+++ b/module-auth/src/test/java/com/inhabas/api/auth/domain/oauth2/handler/Oauth2AuthenticationSuccessHandlerTest.java
@@ -87,8 +87,7 @@ public class Oauth2AuthenticationSuccessHandlerTest {
 
     // then
     assertThat(response.getRedirectedUrl())
-        .contains(
-            VALID_REDIRECT_URL, "accessToken", "refreshToken", "expiresIn", "imageUrl");
+        .contains(VALID_REDIRECT_URL, "accessToken", "refreshToken", "expiresIn", "imageUrl");
   }
 
   @DisplayName("인가되지 않은 redirect_url 요청 시, UnauthorizedRedirectUriException 발생")

--- a/module-auth/src/test/java/com/inhabas/api/auth/domain/oauth2/majorInfo/domain/valueObject/CollegeTest.java
+++ b/module-auth/src/test/java/com/inhabas/api/auth/domain/oauth2/majorInfo/domain/valueObject/CollegeTest.java
@@ -12,7 +12,7 @@ public class CollegeTest {
 
   @DisplayName("College 타입에 제목을 저장한다.")
   @Test
-  public void College_is_OK() {
+  public void saveValidCollegeName() {
 
     // given
     String collegeString = "사회과학대학";
@@ -26,7 +26,7 @@ public class CollegeTest {
 
   @DisplayName("College 타입에 너무 긴 이름을 저장한다. 20자 이상")
   @Test
-  public void College_is_too_long() {
+  public void throwExceptionWhenSavingTooLongCollegeName() {
 
     // given
     String collegeString = "지금이문장은10자임".repeat(20);
@@ -37,14 +37,14 @@ public class CollegeTest {
 
   @DisplayName("College 은 null 일 수 없습니다.")
   @Test
-  public void College_cannot_be_Null() {
+  public void throwExceptionWhenSavingNullCollegeName() {
 
     assertThrows(InvalidInputException.class, () -> new College(null));
   }
 
   @DisplayName("College 은 빈 문자열일 수 없습니다.")
   @Test
-  public void College_cannot_be_Blank() {
+  public void throwExceptionWhenSavingBlankCollegeName() {
 
     assertThrows(InvalidInputException.class, () -> new College("\t"));
   }

--- a/module-auth/src/test/java/com/inhabas/api/auth/domain/oauth2/majorInfo/domain/valueObject/MajorTest.java
+++ b/module-auth/src/test/java/com/inhabas/api/auth/domain/oauth2/majorInfo/domain/valueObject/MajorTest.java
@@ -12,7 +12,7 @@ public class MajorTest {
 
   @DisplayName("Major 타입에 제목을 저장한다.")
   @Test
-  public void Major_is_OK() {
+  public void saveValidMajorName() {
 
     // given
     String majorString = "컴퓨터공학과";
@@ -26,7 +26,7 @@ public class MajorTest {
 
   @DisplayName("Major 타입에 너무 긴 이름을 저장한다. 50자 이상")
   @Test
-  public void Major_is_too_long() {
+  public void throwExceptionWhenSavingTooLongMajorName() {
 
     // given
     String majorString = "지금이문장은10자임".repeat(50);
@@ -37,14 +37,14 @@ public class MajorTest {
 
   @DisplayName("Major 은 null 일 수 없습니다.")
   @Test
-  public void Major_cannot_be_Null() {
+  public void throwExceptionWhenSavingNullMajorName() {
 
     assertThrows(InvalidInputException.class, () -> new Major(null));
   }
 
   @DisplayName("Major 은 빈 문자열일 수 없습니다.")
   @Test
-  public void Major_cannot_be_Blank() {
+  public void throwExceptionWhenSavingBlankMajorName() {
 
     assertThrows(InvalidInputException.class, () -> new Major("\t"));
   }

--- a/module-auth/src/test/java/com/inhabas/api/auth/domain/oauth2/majorInfo/usecase/MajorInfoServiceTest.java
+++ b/module-auth/src/test/java/com/inhabas/api/auth/domain/oauth2/majorInfo/usecase/MajorInfoServiceTest.java
@@ -9,7 +9,6 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.test.util.ReflectionTestUtils;
@@ -33,26 +32,25 @@ public class MajorInfoServiceTest {
 
   @Mock private MajorInfoRepository majorInfoRepository;
 
+  private List<MajorInfo> createSampleMajorInfos() {
+    MajorInfo majorInfo1 = createMajorInfo("공과대학", "기계공학과", 1);
+    MajorInfo majorInfo2 = createMajorInfo("자연과학대학", "수학과", 2);
+    MajorInfo majorInfo3 = createMajorInfo("경영대학", "경영학과", 3);
+    return List.of(majorInfo1, majorInfo2, majorInfo3);
+  }
+
+  private MajorInfo createMajorInfo(String college, String major, int id) {
+    MajorInfo majorInfo = new MajorInfo(college, major);
+    ReflectionTestUtils.setField(majorInfo, "id", id);
+    return majorInfo;
+  }
+
   @DisplayName("모든 학과 정보를 불러온다.")
   @Test
-  public void findAllTest() {
+  public void getAllMajorInfoTest() {
 
     // given
-    MajorInfo majorInfo1 = new MajorInfo("공과대학", "기계공학과");
-    MajorInfo majorInfo2 = new MajorInfo("자연과학대학", "수학과");
-    MajorInfo majorInfo3 = new MajorInfo("경영대학", "경영학과");
-    ReflectionTestUtils.setField(majorInfo1, "id", 1);
-    ReflectionTestUtils.setField(majorInfo2, "id", 2);
-    ReflectionTestUtils.setField(majorInfo3, "id", 3);
-    List<MajorInfo> majorInfos =
-        new ArrayList<>() {
-          {
-            add(majorInfo1);
-            add(majorInfo2);
-            add(majorInfo3);
-          }
-        };
-
+    List<MajorInfo> majorInfos = createSampleMajorInfos();
     given(majorInfoRepository.findAll()).willReturn(majorInfos);
 
     // when
@@ -68,7 +66,7 @@ public class MajorInfoServiceTest {
 
   @DisplayName("새로운 학과를 추가한다.")
   @Test
-  public void saveMajorInfoTest() {
+  public void saveNewMajorInfoTest() {
 
     // given
     MajorInfoSaveDto newMajor = new MajorInfoSaveDto("경영대학", "글로벌금융학과");


### PR DESCRIPTION
- cookie/CookieUtilsTest.java : JUnit방식의 전통적인 가독성이 떨어지는 코드를 개선, 중복 코드 분리, 가독성을 위해 상수 사용

- cookie/HttpCookieOAuth2HttpCookieOAuth2AuthorizationRequestRepositoryTest.java : BeforeEach 추가, Unit방식의 전통적인 가독성이 떨어지는 코드를 개선, 중복 코드 분리, 가독성을 위해 상수 사용

- handler/Oauth2AuthenticationFailureHandlerTest.java : 중복 코드 메서드 분리, URL과 같은 반복적으로 사용되는 문자열은 상수로 정의하여 코드의 가독성 증가

- handler/Oauth2AuthenticationFailureHandlerTest.java : 중복 코드 메서드 분리, URL과 같은 반복적으로 사용되는 문자열은 상수로 정의하여 코드의 가독성 증가, 오타 수정
 
- majorInfo/domain/valueObject/CollegeTest : 메서드 이름 개선

- majorInfo/domain/valueObject/majorTest : 메서드 이름 개선

- majorInfo/usecase/MajorInfoTest : createSampleMajorInfos와 createMajorInfo 메서드를 추가, 메서드 이름 개선

[build Message]
> Task :module-auth:test
2024-11-03 18:34:34.063  INFO 26123 --- [ionShutdownHook] j.LocalContainerEntityManagerFactoryBean : Closing JPA EntityManagerFactory for persistence unit 'default'
2024-11-03 18:34:34.064  INFO 26123 --- [ionShutdownHook] .SchemaDropperImpl$DelayedDropActionImpl : HHH000477: Starting delayed evictData of schema as part of SessionFactory shut-down'
Hibernate: drop table if exists major CASCADE 
Hibernate: drop table if exists refresh_token CASCADE 
Hibernate: drop table if exists update_name_request CASCADE 
Hibernate: drop table if exists user CASCADE 
Hibernate: drop table if exists user_socialaccount CASCADE 
2024-11-03 18:34:34.077  INFO 26123 --- [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Shutdown initiated...
2024-11-03 18:34:34.082  INFO 26123 --- [ionShutdownHook] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Shutdown completed.

BUILD SUCCESSFUL in 27s
