### PR TITLE
[chore/#350] Java 11→17 업그레이드 및 빌드 환경 개선

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -13,11 +13,11 @@ jobs:
     - name: Checkout sources
       uses: actions/checkout@v4
 
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:
-        java-version: '11'
-        distribution: 'adopt'
+        java-version: '17'
+        distribution: 'temurin'
 
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v3

--- a/.github/workflows/depoly-production.yml
+++ b/.github/workflows/depoly-production.yml
@@ -13,11 +13,11 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: '11'
-          distribution: 'adopt'
+          java-version: '17'
+          distribution: 'temurin'
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v3

--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -16,11 +16,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: '11'
-          distribution: 'adopt'
+          java-version: '17'
+          distribution: 'temurin'
 
       - name: Cache Gradle packages
         uses: actions/cache@v3

--- a/.github/workflows/spotless-check.yml
+++ b/.github/workflows/spotless-check.yml
@@ -8,11 +8,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: '11'
-          distribution: 'adopt'
+          java-version: '17'
+          distribution: 'temurin'
 
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-jre-slim as spring
+FROM openjdk:17-jre-slim as spring
 
 ARG JAR_FILE=./resource-server/build/libs/resource-server-0.0.1-SNAPSHOT.jar
 

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,12 @@ subprojects {
 
     group = 'com.inhabas'
     version = '0.0.1-SNAPSHOT'
-    sourceCompatibility = '11'
+
+    java {
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(17)
+        }
+    }
 
     repositories {
         mavenCentral()
@@ -137,7 +142,6 @@ project(':module-auth') {
         // security
         api 'org.springframework.boot:spring-boot-starter-security'
         api 'org.springframework.boot:spring-boot-starter-oauth2-client'
-        api 'org.springframework.security:spring-security-core:5.1.6.RELEASE'
         api 'javax.xml.bind:jaxb-api'
         testImplementation 'org.springframework.security:spring-security-test'
         testImplementation 'org.mockito:mockito-inline:2.13.0'


### PR DESCRIPTION
* build.gradle
  - Java Toolchain 적용: targetCompatibility 설정을 제거하고 Java Toolchain을 사용하여 빌드 환경의 일관성 보장
  - Spring Security 의존성 정리: spring-security-core:5.1.6.RELEASE 직접 지정을 제거하고, Java 17과의 호환성을 위해 Spring Boot BOM이 관리하는 버전 사용
* Dockerfile
  - Base Image 업데이트: 베이스 이미지를 JDK 17 버전으로 변경
* GitHub Workflows
  - JDK 버전 및 배포판 변경: Java 버전을 17로 변경하고, AdoptOpenJDK가 Eclipse Temurin으로 이전됨에 따라 공식 권장 배포판인 Eclipse Temurin을 사용하도록 변경

Refs #350

Clean build 테스트 통과 확인했습니다.